### PR TITLE
Prepend `com.microsoft.` to all main modules

### DIFF
--- a/core/api/src/main/java/module-info.java
+++ b/core/api/src/main/java/module-info.java
@@ -31,7 +31,7 @@ import com.microsoft.gctoolkit.jvm.JavaVirtualMachine;
  * @uses JavaVirtualMachine
  * @uses Aggregator
  */
-module gctoolkit.api {
+module com.microsoft.gctoolkit.api {
 
     exports com.microsoft.gctoolkit;
     exports com.microsoft.gctoolkit.aggregator;

--- a/core/api/src/test/java/module-info.java
+++ b/core/api/src/test/java/module-info.java
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 open module gctoolkit.api.test {
-    requires gctoolkit.api;
+    requires com.microsoft.gctoolkit.api;
     requires java.logging;
     requires org.junit.jupiter.api;
     requires org.junit.jupiter.engine;

--- a/core/parser/src/main/java/module-info.java
+++ b/core/parser/src/main/java/module-info.java
@@ -4,33 +4,36 @@
 /**
  * Contains the GCToolKit GC log parser. The parser is an internal module.
  */
-module gctoolkit.parser {
+module com.microsoft.gctoolkit.parser {
 
     exports com.microsoft.gctoolkit.parser to
             gctoolkit.parser.test,
-            gctoolkit.vertx;
+            com.microsoft.gctoolkit.vertx;
 
     exports com.microsoft.gctoolkit.parser.collection to
             gctoolkit.parser.test;
 
     exports com.microsoft.gctoolkit.parser.io to
             gctoolkit.parser.test,
-            gctoolkit.vertx;
+            com.microsoft.gctoolkit.vertx;
 
     exports com.microsoft.gctoolkit.parser.jvm to
             gctoolkit.parser.test,
-            gctoolkit.vertx;
+            com.microsoft.gctoolkit.vertx;
 
     exports com.microsoft.gctoolkit.parser.unified to
             gctoolkit.parser.test,
-            gctoolkit.vertx;
+            com.microsoft.gctoolkit.vertx;
 
     exports com.microsoft.gctoolkit.parser.vmops to
             gctoolkit.parser.test,
-            gctoolkit.vertx;
-    exports com.microsoft.gctoolkit.parser.datatype to gctoolkit.parser.test, gctoolkit.vertx;
+            com.microsoft.gctoolkit.vertx;
 
-    requires gctoolkit.api;
+    exports com.microsoft.gctoolkit.parser.datatype to
+            gctoolkit.parser.test,
+            com.microsoft.gctoolkit.vertx;
+
+    requires com.microsoft.gctoolkit.api;
     requires java.logging;
 
 }

--- a/core/parser/src/test/java/module-info.java
+++ b/core/parser/src/test/java/module-info.java
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 open module gctoolkit.parser.test {
 
-    requires gctoolkit.api;
-    requires gctoolkit.parser;
+    requires com.microsoft.gctoolkit.api;
+    requires com.microsoft.gctoolkit.parser;
     requires java.logging;
 
     requires org.junit.jupiter.engine;

--- a/core/vertx/src/main/java/module-info.java
+++ b/core/vertx/src/main/java/module-info.java
@@ -8,7 +8,7 @@ import com.microsoft.gctoolkit.vertx.jvm.DefaultJavaVirtualMachine;
  * Contains a vertx based implementation of GCToolKit. The vertx implementation is an internal module.
  * @provides com.microsoft.gctoolkit.jvm.JavaVirtualMachine
  */
-module gctoolkit.vertx {
+module com.microsoft.gctoolkit.vertx {
     exports com.microsoft.gctoolkit.vertx to
             gctoolkit.vertx.test;
 
@@ -19,13 +19,13 @@ module gctoolkit.vertx {
             gctoolkit.vertx.test;
 
     exports com.microsoft.gctoolkit.vertx.jvm to
-            gctoolkit.api,
+            com.microsoft.gctoolkit.api,
             gctoolkit.vertx.test;
 
     provides JavaVirtualMachine with DefaultJavaVirtualMachine;
 
-    requires gctoolkit.api;
-    requires gctoolkit.parser;
+    requires com.microsoft.gctoolkit.api;
+    requires com.microsoft.gctoolkit.parser;
     requires java.logging;
     requires io.vertx.core;
 }

--- a/core/vertx/src/test/java/module-info.java
+++ b/core/vertx/src/test/java/module-info.java
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 open module gctoolkit.vertx.test {
-    requires gctoolkit.api;
-    requires gctoolkit.parser;
-    requires gctoolkit.vertx;
+    requires com.microsoft.gctoolkit.api;
+    requires com.microsoft.gctoolkit.parser;
+    requires com.microsoft.gctoolkit.vertx;
     requires java.logging;
     requires io.vertx.core;
 

--- a/sample/src/main/java/module-info.java
+++ b/sample/src/main/java/module-info.java
@@ -9,11 +9,11 @@ import com.microsoft.gctoolkit.sample.aggregation.HeapOccupancyAfterCollectionSu
  */
 module gctoolkit.sample {
 
-    requires gctoolkit.api;
-    requires gctoolkit.vertx;
+    requires com.microsoft.gctoolkit.api;
+    requires com.microsoft.gctoolkit.vertx;
     requires java.logging;
 
-    exports com.microsoft.gctoolkit.sample.aggregation to gctoolkit.vertx;
+    exports com.microsoft.gctoolkit.sample.aggregation to com.microsoft.gctoolkit.vertx;
 
     provides Aggregation with HeapOccupancyAfterCollectionSummary;
 }


### PR DESCRIPTION
Addresses first task of
- #13

I left the internal test modules untouched, as they are not meant to re-used by others, i.e. they are not published to Maven Central.