### PR TITLE
Make use of `javac`'s `--release` option

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,11 +16,6 @@
         <module>vertx</module>
     </modules>
 
-    <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
          
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdk.version>11</jdk.version>
+        <maven.compiler.release>11</maven.compiler.release>
         <skipUnpack>false</skipUnpack>
     </properties>
 
@@ -107,10 +107,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
-                    <configuration>
-                        <source>${jdk.version}</source>
-                        <target>${jdk.version}</target>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Prior to this commit the `-source` and `-target` option were used in two different ways.

This commit merges the two (old) options into the new one and also removes a configuration duplication.