### PR TITLE
Compile version information into Java modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>--module-version=${project.version}</arg>
+                        </compilerArgs>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Prior to this commit, the version information set and managed by Maven
is lost in translation. This commit configures the root compiler plugin
to include the version information into the compiled module descriptors.

The version information will appear in Java's stack traces as well as
when module descriptions are printed.

For example for `2.0.1-SNAPSHOT`:

```text
java --module-path classes --describe-module com.microsoft.gctoolkit.api

com.microsoft.gctoolkit.api@2.0.1-SNAPSHOT file:///.../gctoolkit/core/api/target/classes/

exports com.microsoft.gctoolkit
...
exports com.microsoft.gctoolkit.time
requires java.base mandated
requires java.logging
uses com.microsoft.gctoolkit.aggregator.Aggregation
uses com.microsoft.gctoolkit.jvm.JavaVirtualMachine
```