### PR TITLE
typo spelling grammar fixing

### DIFF
--- a/core/api/src/main/java/com/microsoft/gctoolkit/aggregator/JVMEventDispatcher.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/aggregator/JVMEventDispatcher.java
@@ -42,7 +42,7 @@ public class JVMEventDispatcher {
             }
 
             if (clazz == JVMEvent.class) {
-                // Hit the top of the hierachy
+                // Hit the top of the hierarchy
                 break;
             } else {
                 //Unfortunate cast but assuming register has done its job it is impossible for this cast to fail

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
@@ -566,7 +566,7 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
         record(collection);
     }
 
-    //Very rare occurance where ParNew suffers from a promotion failure during the reset. This is, and isn't a CMF but will be treated as one.
+    //Very rare occurence where ParNew suffers from a promotion failure during the reset. This is, and isn't a CMF but will be treated as one.
     public void parNewToPsudoConcurrentModeFailure(GCLogTrace trace, String line) {
         ConcurrentModeFailure collection = new ConcurrentModeFailure(scavengeTimeStamp, GCCause.PROMOTION_FAILED, trace.getDoubleGroup(trace.groupCount()));
         MemoryPoolSummary tenured = trace.getOccupancyBeforeAfterWithMemoryPoolSizeSummary(1);

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ParallelPatterns.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ParallelPatterns.java
@@ -28,7 +28,7 @@ public interface ParallelPatterns extends SharedPatterns {
     GCParseRule SERIAL_FULL_REFERENCE = new GCParseRule("SERIAL_FULL_REFERENCE", FULL_GC_PREFIX + DATE_TIMESTAMP + "\\[Tenured" + REFERENCE_RECORDS + ": " + BEFORE_AFTER_CONFIGURED_PAUSE + "\\] " + BEFORE_AFTER_CONFIGURED + "\\, " + PERM_RECORD + ", " + PAUSE_TIME);
     GCParseRule PS_FULL_REFERENCE = new GCParseRule("PS_FULL_REFERENCE", FULL_GC_PREFIX + REFERENCE_RECORDS + "\\s*" + PS_BLOCK + " \\[(?:PSFull|PSOldGen|ParOldGen): " + BEFORE_AFTER_CONFIGURED + "\\] " + BEFORE_AFTER_CONFIGURED + "(?:,)? " + PERM_RECORD + ", " + PAUSE_TIME);
 
-    //Moronic HotSpot/GC developers decided on yet another arbitrary format change... Why we need the comma... beyound me!
+    //Moronic HotSpot/GC developers decided on yet another arbitrary format change... Why we need the comma... beyond me!
     //22.014: [Full GC (Metadata GC Threshold) [PSYoungGen: 16865K->0K(107008K)] [ParOldGen: 108907K->103881K(124416K)] 125773K->103881K(231424K), [Metaspace: 21089K->21089K(1067008K)], 0.2715010 secs]
     //0.221: [Full GC (Ergonomics) [PSYoungGen: 10736K->0K(76288K)] [ParOldGen: 120258K->115108K(175104K)] 130995K->115108K(251392K), [Metaspace: 4209K->4207K(1056768K)], 0.0235254 secs]
     //42384.024: [Full GC [PSYoungGen: 1696K->0K(70464K)] [PSFull: 928442K->125867K(932096K)] 930139K->125867K(1002560K) [PSPermGen: 37030K->37030K(65536K)], 117.0312620 secs]

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/PreUnifiedJVMConfiguration.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/PreUnifiedJVMConfiguration.java
@@ -722,7 +722,7 @@ public class PreUnifiedJVMConfiguration implements SimplePatterns, CMSPatterns, 
      *
      * The following table bit encodes all of the Collector flags. The flags cannot be acted upon until all of the
      * flags have been seen as not all combinations of flags are valid and certain combinations will yield unexpected
-     * configurations. The method evaluateGCLogFlags() will examine the flags and set the corrisponding values in the
+     * configurations. The method evaluateGCLogFlags() will examine the flags and set the corresponding values in the
      * deriveConfiguration.
      *
      * GC Flag                  Bit Value

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/UnifiedLoggingTokens.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/UnifiedLoggingTokens.java
@@ -31,7 +31,7 @@ public interface UnifiedLoggingTokens extends GenericTokens {
     String PID_TID = "\\[\\d+\\]";
     String UNIFIED_LOG_LEVEL_BLOCK = "\\[(error|warning|info|debug|trace|develop)\\]";
     Pattern DECORATORS = Pattern.compile("(" + DATE_STAMP + ")?(" + UPTIME + ")?(" + TIME_MILLIS + ")?(" + TIME_MILLIS + ")?(" + TIME_NANOS + ")?(" + TIME_NANOS + ")?(" + PID_TID + ")?(" + PID_TID + ")?(" + UNIFIED_LOG_LEVEL_BLOCK + ")?");
-    //Using zero-width negative lookbehind to miss capturing records formated like [0x1f03].
+    //Using zero-width negative lookbehind to miss capturing records formatted like [0x1f03].
     //[0.081s][trace][safepoint] Thread: 0x00007fd0d2006800  [0x1f03] State: _at_safepoint _has_called_back 0 _at_poll_safepoint 0
     Pattern TAGS = Pattern.compile(".*(?<=^|\\])\\[([a-z0-9,. ]+)\\]");
 


### PR DESCRIPTION
## description
fix typo spelling grammar separate files and change to correct one with reference from [merriam webster](merriam-webster.com)

## testing
testing not include because just replace the typo spelling