### PR TITLE
remove dependency on top-level gctoolkit-testdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ You must also add `github` as a server in your `~/.m2/settings.xml` file. Replac
     </server>
 ```
 
----
-
 ## Getting Started
 
 ### Maven Coordinates
@@ -83,6 +81,11 @@ The build is vanilla Maven.
 * `mvn compile` - compile the source code
 * `mvn test` - run unit tests (this project uses TestNG)
 * `mvn package` - build the .jar files
+
+### Additional build properties
+* `skipUnpack` - boolean. Defaults to `false`. This tells the build to skip unpacking the gctoolkit-testdata logs. 
+If the test data has already be extracted to the gclogs directory, setting this property to `true` can save 
+a minute or so of build time.
 
 ## Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,13 +80,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.microsoft.gctoolkit</groupId>
-                <artifactId>gctoolkit-testdata</artifactId>
-                <version>${gctoolkit-testdata-version}</version>
-                <type>zip</type>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>5.7.2</version>


### PR DESCRIPTION
The top-level POM file has a dependency on gctoolkit-testdata. This means that when someone runs a build, the gctoolkit-testdata pom file is downloaded. But nothing is done with that dependency. The individual gclog zip files are still downloaded by the maven-dependecy-plugin. 

The other benefit of doing this is that someone can run a maven build with -DskipTests -DskipUnpack and the gctoolkit-testdata will not be downloaded. This could be recommended for someone who wants to build but doesn't want to test. It is unfortunate that skipUnpack cannot be conditional on skipTests. But we can solve that by defaulting skipUnpack and skipTests to true, and having a `contributor` profile that sets them to false. I'll create an issue for that. 

Oh, and I doc'd skipUnpack in README