### PR TITLE
suppress unchecked cast warnings

### DIFF
--- a/core/api/src/main/java/com/microsoft/gctoolkit/aggregator/JVMEventDispatcher.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/aggregator/JVMEventDispatcher.java
@@ -17,6 +17,7 @@ public class JVMEventDispatcher {
     private final Consumer<JVMEvent> nopConsumer = (evt) -> {
     };
 
+    @SuppressWarnings("unchecked")
     private <R extends JVMEvent> Consumer<JVMEvent> getConsumerForClass(Class<R> eventClass) {
         Class<? extends JVMEvent> clazz = eventClass;
 
@@ -45,8 +46,8 @@ public class JVMEventDispatcher {
                 // Hit the top of the hierarchy
                 break;
             } else {
-                //Unfortunate cast but assuming register has done its job it is impossible for this cast to fail
-                clazz = (Class<? extends JVMEvent>) clazz.getSuperclass();
+                // Unfortunate cast but assuming register has done its job it is impossible for this cast to fail
+                clazz = (Class<? extends JVMEvent>) clazz.getSuperclass(); // unchecked cast
             }
         } while (clazz != null);
 
@@ -61,8 +62,9 @@ public class JVMEventDispatcher {
      * @param process A method to call back when an event of type {@code eventClass} is captured.
      * @param <R> A type of JVMEvent
      */
+    @SuppressWarnings("unchecked")
     public <R extends JVMEvent> void register(Class<R> eventClass, Consumer<? super R> process) {
-        eventConsumers.put(eventClass, (Consumer<JVMEvent>)process);
+        eventConsumers.put(eventClass, (Consumer<JVMEvent>)process); // unchecked cast
     }
 
     /**

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/collection/MRUQueue.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/collection/MRUQueue.java
@@ -20,10 +20,12 @@ public class MRUQueue<K, V> implements Map<K, V>, Iterable<K> {
         keys = new LinkedList<>();
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
     public V get(Object key) {
         keys.remove(key);
         if (key != null) {
-            keys.offerFirst((K) key);
+            keys.offerFirst((K)key); // unchecked cast
             return entries.get(key);
         }
         return null;


### PR DESCRIPTION
Suppress annoying compiler warning. The uncheck casts in JVMEventDispatcher are safe. The one in MRUQueue could still result in a ClassCastException, but we know from how/where MRUQueue is used that a ClassCastException will not occur.