### PR TITLE
add RuntimeAggregation

### DIFF
--- a/core/api/src/main/java/com/microsoft/gctoolkit/aggregations/RuntimeAggregation.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/aggregations/RuntimeAggregation.java
@@ -1,0 +1,75 @@
+package com.microsoft.gctoolkit.aggregations;
+
+import com.microsoft.gctoolkit.aggregator.Aggregation;
+import com.microsoft.gctoolkit.time.DateTimeStamp;
+
+/**
+ * An Aggregation that collates runtime data. This class is meant to be extended by other
+ * implementations that need access to runtime data to perform calculations. For example,
+ * to calculate the ratio of pause time to runtime duration.
+ */
+public abstract class RuntimeAggregation  implements Aggregation {
+
+    private volatile DateTimeStamp timeOfFirstEvent = null;
+    private volatile DateTimeStamp timeOfLastEvent = new DateTimeStamp(0d);
+
+    /**
+     * Runtime duration (in decimal seconds) after which we no longer consider the GC log to be a fragment
+     */
+    private static final double LOG_FRAGMENT_THRESHOLD = 18d;
+
+    /**
+     * This class is meant to be extended.
+     */
+    protected RuntimeAggregation() {}
+
+    /**
+     * RuntimeAggregation collates the time of an event and the duration of the event.
+     * @param eventTime The time a JVMEvent occurred.
+     * @param duration The duration of the JVMEvent.
+     */
+    public void record(DateTimeStamp eventTime, double duration) {
+        duration = !Double.isNaN(duration) ? duration : 0d;
+
+        if (timeOfFirstEvent == null || (eventTime != null && eventTime.before(timeOfFirstEvent))) {
+            timeOfFirstEvent = eventTime != null ? eventTime : new DateTimeStamp(0d);
+        }
+
+        final DateTimeStamp now =
+                eventTime != null ? eventTime.add(duration) : timeOfLastEvent.add(duration);
+        if (now.after(timeOfLastEvent)) {
+            timeOfLastEvent = now;
+        }
+    }
+
+    /**
+     * Return the time of the first event of the GC log.
+     * @return The time of the first event.
+     */
+    public DateTimeStamp getTimeOfFirstEvent() {
+        return timeOfFirstEvent != null ? timeOfFirstEvent : new DateTimeStamp(0.0);
+    }
+
+    /**
+     * Return the time of the last event of the GC log.
+     * Note well! The time of the last event is not the start time of the event, but is the
+     * time the event ended (event start time plus the event duration).
+     * @return The time of the last event.
+     */
+    public DateTimeStamp getTimeOfLastEvent() {
+        return timeOfLastEvent != null ? timeOfLastEvent : getTimeOfFirstEvent();
+    }
+
+    /**
+     * Return the duration of the GC log. Fundamentally, this is the difference between the
+     * time of the last event and the time of the first event.
+     * @return The time of the first event.
+     */
+    public double getRuntimeDuration() {
+        double duration = getTimeOfLastEvent().minus(getTimeOfFirstEvent());
+        boolean isLogFragment = duration < LOG_FRAGMENT_THRESHOLD;
+        return !isLogFragment
+                ? duration
+                : getTimeOfLastEvent().getTimeStamp();
+    }
+}

--- a/core/api/src/main/java/com/microsoft/gctoolkit/aggregators/RuntimeAggregator.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/aggregators/RuntimeAggregator.java
@@ -1,0 +1,31 @@
+package com.microsoft.gctoolkit.aggregators;
+
+import com.microsoft.gctoolkit.aggregations.RuntimeAggregation;
+import com.microsoft.gctoolkit.aggregator.Aggregator;
+import com.microsoft.gctoolkit.event.jvm.JVMEvent;
+import com.microsoft.gctoolkit.event.jvm.JVMTermination;
+
+/**
+ * An Aggregator that collects only the DateTimeStamp and duration of a JVMEvent.
+ */
+public class RuntimeAggregator extends Aggregator<RuntimeAggregation> {
+
+    protected RuntimeAggregator(RuntimeAggregation aggregation) {
+        super(aggregation);
+    }
+
+    // This is atypical of an Aggregator. The typical pattern is to register the method that processes
+    // an event in the constructor of the Aggregator. Here we rely on the consume(E event) method to
+    // invoke this process method. This ensures that any JVMEvent gets handled by this process method
+    // regardless of what JVMEvent classes are registered by subclasses of RuntimeAggregator.
+    private void process(JVMEvent event) {
+        if (event instanceof JVMTermination) return;
+        aggregation().record(event.getDateTimeStamp(), event.getDuration());
+    }
+
+    @Override
+    public <E extends JVMEvent> void consume(E event) {
+        process(event);
+        super.consume(event);
+    }
+}

--- a/core/api/src/main/java/module-info.java
+++ b/core/api/src/main/java/module-info.java
@@ -34,7 +34,9 @@ import com.microsoft.gctoolkit.jvm.JavaVirtualMachine;
 module com.microsoft.gctoolkit.api {
 
     exports com.microsoft.gctoolkit;
+    exports com.microsoft.gctoolkit.aggregations;
     exports com.microsoft.gctoolkit.aggregator;
+    exports com.microsoft.gctoolkit.aggregators;
     exports com.microsoft.gctoolkit.event;
     exports com.microsoft.gctoolkit.event.g1gc;
     exports com.microsoft.gctoolkit.event.generational;

--- a/core/api/src/test/java/com/microsoft/gctoolkit/test/aggregations/RuntimeAggregationTest.java
+++ b/core/api/src/test/java/com/microsoft/gctoolkit/test/aggregations/RuntimeAggregationTest.java
@@ -1,0 +1,130 @@
+package com.microsoft.gctoolkit.test.aggregations;
+
+import com.microsoft.gctoolkit.aggregations.RuntimeAggregation;
+import com.microsoft.gctoolkit.time.DateTimeStamp;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RuntimeAggregationTest {
+
+    private static class TestRuntimeAggregation extends RuntimeAggregation {
+
+        @Override
+        public boolean hasWarning() {
+            return false;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+    }
+
+    @Test
+    void assertRecordAcceptsNull() {
+        final double duration = 1.5d;
+        TestRuntimeAggregation testRuntimeAggregation = new TestRuntimeAggregation();
+        DateTimeStamp first = new DateTimeStamp(0.0);
+        testRuntimeAggregation.record(null, duration);
+        DateTimeStamp last = first.add(duration);
+        testRuntimeAggregation.record(null, duration);
+        last = last.add(duration);
+        assertEquals(first, testRuntimeAggregation.getTimeOfFirstEvent());
+        assertEquals(last, testRuntimeAggregation.getTimeOfLastEvent());
+        // expect runtime duration to be the time of last event in this case
+        // because timeOfLastEvent().minus(timeOfFirstEvent()) does not exceed
+        // com.li.censum.aggregations.RuntimeAggregation.LOG_FRAGMENT_THRESHOLD.
+        double runtimeDuration = testRuntimeAggregation.getTimeOfLastEvent().getTimeStamp();
+        assertEquals(runtimeDuration, testRuntimeAggregation.getRuntimeDuration());
+
+        final int nTimes = 10;
+        for (int n = 0; n < nTimes; n++) {
+            testRuntimeAggregation.record(null, duration);
+        }
+        // expect runtime duration to be timeOfLastEvent().minus(timeOfFirstEvent())
+        // in this case since the difference exceeds
+        // com.li.censum.aggregations.RuntimeAggregation.LOG_FRAGMENT_THRESHOLD.
+        runtimeDuration =
+                testRuntimeAggregation.getTimeOfLastEvent().minus(testRuntimeAggregation.getTimeOfFirstEvent());
+        assertEquals(runtimeDuration, testRuntimeAggregation.getRuntimeDuration());
+    }
+
+    @Test
+    void assertRecordAcceptsNaN() {
+        final double duration = Double.NaN;
+        final double deltaTime = 1.0d;
+        TestRuntimeAggregation testRuntimeAggregation = new TestRuntimeAggregation();
+        DateTimeStamp first = new DateTimeStamp(0.0d);
+        DateTimeStamp last = first.add(deltaTime);
+        testRuntimeAggregation.record(first, Double.NaN);
+        testRuntimeAggregation.record(last, Double.NaN);
+        assertEquals(first, testRuntimeAggregation.getTimeOfFirstEvent());
+        assertEquals(last, testRuntimeAggregation.getTimeOfLastEvent());
+        // expect runtime duration to be the time of last event in this case
+        // because timeOfLastEvent().minus(timeOfFirstEvent()) does not exceed
+        // com.li.censum.aggregations.RuntimeAggregation.LOG_FRAGMENT_THRESHOLD.
+        double runtimeDuration = testRuntimeAggregation.getTimeOfLastEvent().getTimeStamp();
+        assertEquals(runtimeDuration, testRuntimeAggregation.getRuntimeDuration());
+
+        final int nTimes = 10;
+        for (int n = 0; n < nTimes; n++) {
+            last = last.add(deltaTime);
+            testRuntimeAggregation.record(last, duration);
+        }
+        // expect runtime duration to be timeOfLastEvent().minus(timeOfFirstEvent())
+        // in this case since the difference exceeds
+        // com.li.censum.aggregations.RuntimeAggregation.LOG_FRAGMENT_THRESHOLD.
+        runtimeDuration =
+                testRuntimeAggregation.getTimeOfLastEvent().minus(testRuntimeAggregation.getTimeOfFirstEvent());
+        assertEquals(runtimeDuration, testRuntimeAggregation.getRuntimeDuration());
+    }
+
+    @Test
+    void getTimeOfFirstEvent() {
+        final double duration = 1.5d;
+        final double deltaTime = 1.0d;
+        TestRuntimeAggregation testRuntimeAggregation = new TestRuntimeAggregation();
+        DateTimeStamp first = new DateTimeStamp(0.0);
+        DateTimeStamp last = first;
+        final int nTimes = 10;
+        for (int n = 0; n < nTimes; n++) {
+            testRuntimeAggregation.record(last, duration);
+            last = last.add(deltaTime);
+        }
+        assertEquals(first, testRuntimeAggregation.getTimeOfFirstEvent());
+    }
+
+    @Test
+    void getTimeOfLastEvent() {
+        final double duration = 1.5d;
+        final double deltaTime = 1.0d;
+        TestRuntimeAggregation testRuntimeAggregation = new TestRuntimeAggregation();
+        final DateTimeStamp first = new DateTimeStamp(0.0);
+        DateTimeStamp next = first;
+        final int nTimes = 10;
+        for (int n = 0; n < nTimes; n++) {
+            testRuntimeAggregation.record(next, duration);
+            next = next.add(deltaTime);
+        }
+        DateTimeStamp last = first.add(testRuntimeAggregation.getRuntimeDuration());
+        assertEquals(last, testRuntimeAggregation.getTimeOfLastEvent());
+    }
+
+    @Test
+    void getRuntimeDuration() {
+        final double duration = 1.5d;
+        final double deltaTime = 1.0d;
+        TestRuntimeAggregation testRuntimeAggregation = new TestRuntimeAggregation();
+        final DateTimeStamp first = new DateTimeStamp(0.0);
+        DateTimeStamp next = first;
+        final int nTimes = 10;
+        for (int n = 0; n < nTimes; n++) {
+            testRuntimeAggregation.record(next, duration);
+            next = next.add(deltaTime);
+        }
+        double totalDuration =
+                testRuntimeAggregation.getTimeOfLastEvent().minus(testRuntimeAggregation.getTimeOfFirstEvent());
+        assertEquals(totalDuration, testRuntimeAggregation.getRuntimeDuration());
+    }
+}


### PR DESCRIPTION
Add RuntimeAggregation, which accumulates time of first event, time of last event, and runtime duration. This class is useful as a base for aggregations that need runtime to perform calculations. For example, to calculate the ratio of pause time to runtime. 