### PR TITLE
Sorted the modifiers of fields according to best practices

### DIFF
--- a/core/api/src/main/java/com/microsoft/gctoolkit/aggregator/Aggregator.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/aggregator/Aggregator.java
@@ -62,7 +62,7 @@ public abstract class Aggregator<A extends Aggregation> {
 
     /// JVMEventDispatcher manages all of the registered events and event consumers
     private final JVMEventDispatcher jvmEventDispatcher = new JVMEventDispatcher();
-    volatile private boolean done = false;
+    private volatile boolean done = false;
 
     /**
      * Subclass only.

--- a/core/api/src/main/java/com/microsoft/gctoolkit/collections/XYDataSet.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/collections/XYDataSet.java
@@ -72,8 +72,8 @@ public class XYDataSet {
 
     public static class Point {
 
-        final private Number x;
-        final private Number y;
+        private final Number x;
+        private final Number y;
 
         public Point(Number x, Number y) {
             this.x = x;

--- a/core/api/src/main/java/com/microsoft/gctoolkit/event/GCCauses.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/event/GCCauses.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import static com.microsoft.gctoolkit.event.GCCause.*;
 
 public class GCCauses {
-    private final static Map<String, GCCause> GC_CAUSES = Map.ofEntries(
+    private static final Map<String, GCCause> GC_CAUSES = Map.ofEntries(
         Map.entry(GCCause.JAVA_LANG_SYSTEM.getLabel(), GCCause.JAVA_LANG_SYSTEM),
         Map.entry("System", GCCause.JAVA_LANG_SYSTEM),
         Map.entry(GCCause.DIAGNOSTIC_COMMAND.getLabel(), GCCause.JAVA_LANG_SYSTEM),

--- a/core/api/src/main/java/com/microsoft/gctoolkit/event/StatisticalSummary.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/event/StatisticalSummary.java
@@ -4,7 +4,7 @@ package com.microsoft.gctoolkit.event;
 
 public class StatisticalSummary {
 
-    final static public double UNDEFINED = -1.0d;
+    public static final double UNDEFINED = -1.0d;
 
     private final double min;
     private final double average;

--- a/core/api/src/main/java/com/microsoft/gctoolkit/event/g1gc/G1GCConcurrentEvent.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/event/g1gc/G1GCConcurrentEvent.java
@@ -6,7 +6,7 @@ import com.microsoft.gctoolkit.event.GCCause;
 import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
-abstract public class G1GCConcurrentEvent extends G1GCEvent {
+public abstract class G1GCConcurrentEvent extends G1GCEvent {
 
     public G1GCConcurrentEvent(DateTimeStamp timeStamp, GarbageCollectionTypes type, GCCause cause, double duration) {
         super(timeStamp, type, cause, duration);

--- a/core/api/src/main/java/com/microsoft/gctoolkit/event/g1gc/G1GCEvent.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/event/g1gc/G1GCEvent.java
@@ -8,7 +8,7 @@ import com.microsoft.gctoolkit.event.GCEvent;
 import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
-abstract public class G1GCEvent extends GCEvent {
+public abstract class G1GCEvent extends GCEvent {
 
     public G1GCEvent(DateTimeStamp timeStamp, GarbageCollectionTypes type, GCCause cause, double duration) {
         super(timeStamp, type, cause, duration);

--- a/core/api/src/main/java/com/microsoft/gctoolkit/event/generational/CMSConcurrentEvent.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/event/generational/CMSConcurrentEvent.java
@@ -6,7 +6,7 @@ import com.microsoft.gctoolkit.event.GCCause;
 import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
-abstract public class CMSConcurrentEvent extends GenerationalGCEvent implements CMSPhase {
+public abstract class CMSConcurrentEvent extends GenerationalGCEvent implements CMSPhase {
 
     private double cpuTime;
     private double wallClockTime;

--- a/core/api/src/main/java/com/microsoft/gctoolkit/event/generational/CMSPauseEvent.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/event/generational/CMSPauseEvent.java
@@ -6,7 +6,7 @@ import com.microsoft.gctoolkit.event.GCCause;
 import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
-abstract public class CMSPauseEvent extends GenerationalGCPauseEvent implements CMSPhase {
+public abstract class CMSPauseEvent extends GenerationalGCPauseEvent implements CMSPhase {
 
     public CMSPauseEvent(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, GCCause cause, double duration) {
         super(timeStamp, gcType, cause, duration);

--- a/core/api/src/main/java/com/microsoft/gctoolkit/event/zgc/OccupancySummary.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/event/zgc/OccupancySummary.java
@@ -4,9 +4,9 @@ package com.microsoft.gctoolkit.event.zgc;
 
 public class OccupancySummary {
 
-    final private long markEnd;
-    final private long reclaimStart;
-    final private long reclaimEnd;
+    private final long markEnd;
+    private final long reclaimStart;
+    private final long reclaimEnd;
 
 
     public OccupancySummary(long markEnd, long reclaimStart, long reclaimEnd) {

--- a/core/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ReclaimSummary.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ReclaimSummary.java
@@ -4,8 +4,8 @@ package com.microsoft.gctoolkit.event.zgc;
 
 public class ReclaimSummary {
 
-    final private long reclaimStart;
-    final private long reclaimEnd;
+    private final long reclaimStart;
+    private final long reclaimEnd;
 
     public ReclaimSummary(long reclaimStart, long reclaimEnd) {
         this.reclaimStart = reclaimStart;

--- a/core/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMemoryPoolSummary.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMemoryPoolSummary.java
@@ -5,10 +5,10 @@ package com.microsoft.gctoolkit.event.zgc;
 public class ZGCMemoryPoolSummary {
 
     // these are effectively final but David likes to see an explicit final. In Java 14 this could be a Record.
-    final private long capacity;
-    final private long reserved;
-    final private long free;
-    final private long used;
+    private final long capacity;
+    private final long reserved;
+    private final long free;
+    private final long used;
 
     public ZGCMemoryPoolSummary(long capacity, long reserved, long free, long used) {
         this.capacity = capacity;

--- a/core/api/src/main/java/com/microsoft/gctoolkit/io/FileDataSourceMetaData.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/io/FileDataSourceMetaData.java
@@ -15,7 +15,7 @@ import java.util.zip.ZipFile;
  */
 public class FileDataSourceMetaData {
 
-    private final static Logger LOG = Logger.getLogger(FileDataSourceMetaData.class.getName());
+    private static final Logger LOG = Logger.getLogger(FileDataSourceMetaData.class.getName());
 
     private static final int GZIP_MAGIC1 = 0x1F;
     private static final int GZIP_MAGIC2 = 0x8b;

--- a/core/api/src/main/java/com/microsoft/gctoolkit/io/RotatingGCLogFile.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/io/RotatingGCLogFile.java
@@ -34,7 +34,7 @@ import java.util.zip.ZipFile;
  */
 public class RotatingGCLogFile extends GCLogFile {
 
-    private final static Logger LOGGER = Logger.getLogger(RotatingGCLogFile.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(RotatingGCLogFile.class.getName());
 
     private static boolean isUnifiedLogging(Path path) {
         try {

--- a/core/api/src/main/java/com/microsoft/gctoolkit/io/SingleGCLogFile.java
+++ b/core/api/src/main/java/com/microsoft/gctoolkit/io/SingleGCLogFile.java
@@ -21,7 +21,7 @@ import java.util.zip.ZipInputStream;
  */
 public class SingleGCLogFile extends GCLogFile {
 
-    private final static Logger LOGGER = Logger.getLogger(SingleGCLogFile.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(SingleGCLogFile.class.getName());
 
     private static boolean isUnifiedLogging(Path path) {
         try {

--- a/core/api/src/test/java/com/microsoft/gctoolkit/test/time/DateTimeStampTest.java
+++ b/core/api/src/test/java/com/microsoft/gctoolkit/test/time/DateTimeStampTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class DateTimeStampTest {
 
     // For some reason, ISO_DATE_TIME doesn't like that time-zone is -0100. It wants -01:00.
-    private final static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
     @Test
     void getTimeStamp() {

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/CMSTenuredPoolParser.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/CMSTenuredPoolParser.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
 
 public class CMSTenuredPoolParser extends PreUnifiedGCLogParser implements SimplePatterns, ICMSPatterns {
 
-    private final static Logger LOG = Logger.getLogger(CMSTenuredPoolParser.class.getName());
+    private static final Logger LOG = Logger.getLogger(CMSTenuredPoolParser.class.getName());
     private DateTimeStamp startOfPhase = null;
     private GCParseRule EndOfFile = new GCParseRule("END_OF_DATA_SENTINAL", END_OF_DATA_SENTINAL);
 

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ForwardReference.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ForwardReference.java
@@ -9,8 +9,8 @@ import com.microsoft.gctoolkit.parser.jvm.Decorators;
 
 public class ForwardReference {
 
-    final private Decorators decorators;
-    final private int gcID;
+    private final Decorators decorators;
+    private final int gcID;
     private DateTimeStamp startTime = null;
     private double duration = -1.0d;
     private GCCause gcCause = GCCause.UNKNOWN_GCCAUSE;

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
@@ -106,46 +106,46 @@ public class G1GCForwardReference extends ForwardReference {
     /**
      * memory pool statistics
      */
-    private final static int HEAP_OCCUPANCY_BEFORE_COLLECTION = 0;
-    private final static int HEAP_OCCUPANCY_AFTER_COLLECTION = 1;
-    private final static int HEAP_SIZE_BEFORE_COLLECTION = 2;
-    private final static int HEAP_SIZE_AFTER_COLLECTION = 3;
-    private final static int EDEN_OCCUPANCY_BEFORE_COLLECTION = 4;
-    private final static int EDEN_OCCUPANCY_AFTER_COLLECTION = 5;
-    private final static int EDEN_SIZE_BEFORE_COLLECTION = 6;
-    private final static int EDEN_SIZE_AFTER_COLLECTION = 7;
-    private final static int SURVIVOR_OCCUPANCY_BEFORE_COLLECTION = 8;
-    private final static int SURVIVOR_OCCUPANCY_AFTER_COLLECTION = 9;
-    private final static int SURVIVOR_SIZE_BEFORE_COLLECTION = 10;
-    private final static int SURVIVOR_SIZE_AFTER_COLLECTION = 11;
-    private final static int YOUNG_OCCUPANCY_BEFORE_COLLECTION = 12;
-    private final static int YOUNG_OCCUPANCY_AFTER_COLLECTION = 13;
-    private final static int YOUNG_SIZE_BEFORE_COLLECTION = 14;
-    private final static int YOUNG__SIZE_AFTER_COLLECTION = 15;
-    private final static int OLD_OCCUPANCY_BEFORE_COLLECTION = 16;
-    private final static int OLD_OCCUPANCY_AFTER_COLLECTION = 17;
-    private final static int OLD_SIZE_BEFORE_COLLECTION = 18;
-    private final static int OLD_SIZE_AFTER_COLLECTION = 19;
-    private final static int HUMONGOUS_OCCUPANCY_BEFORE_COLLECTION = 20;
-    private final static int HUMONGOUS_OCCUPANCY_AFTER_COLLECTION = 21;
-    private final static int HUMONGOUS_SIZE_BEFORE_COLLECTION = 22;
-    private final static int HUMONGOUS_SIZE_AFTER_COLLECTION = 23;
-    private final static int METASPACE_OCCUPANCY_BEFORE_COLLECTION = 24;
-    private final static int METASPACE_OCCUPANCY_AFTER_COLLECTION = 25;
-    private final static int METASPACE_SIZE_BEFORE_COLLECTION = 26;
-    private final static int METASPACE_SIZE_AFTER_COLLECTION = 27;
-    private final static int METASPACE_COMMITTED_BEFORE_COLLECTION = 28;
-    private final static int METASPACE_COMMITTED_AFTER_COLLECTION = 29;
-    private final static int METASPACE_RESERVED_BEFORE_COLLECTION = 30;
-    private final static int METASPACE_RESERVED_AFTER_COLLECTION = 31;
-    private final static int CLASSSPACE_OCCUPANCY_BEFORE_COLLECTION = 32;
-    private final static int CLASSSPACE_OCCUPANCY_AFTER_COLLECTION = 33;
-    private final static int CLASSSPACE_SIZE_BEFORE_COLLECTION = 34;
-    private final static int CLASSSPACE_SIZE_AFTER_COLLECTION = 35;
-    private final static int CLASSSPACE_COMMITTED_BEFORE_COLLECTION = 36;
-    private final static int CLASSSPACE_COMMITTED_AFTER_COLLECTION = 37;
-    private final static int CLASSSPACE_RESERVED_BEFORE_COLLECTION = 38;
-    private final static int CLASSSPACE_RESERVED_AFTER_COLLECTION = 39;
+    private static final int HEAP_OCCUPANCY_BEFORE_COLLECTION = 0;
+    private static final int HEAP_OCCUPANCY_AFTER_COLLECTION = 1;
+    private static final int HEAP_SIZE_BEFORE_COLLECTION = 2;
+    private static final int HEAP_SIZE_AFTER_COLLECTION = 3;
+    private static final int EDEN_OCCUPANCY_BEFORE_COLLECTION = 4;
+    private static final int EDEN_OCCUPANCY_AFTER_COLLECTION = 5;
+    private static final int EDEN_SIZE_BEFORE_COLLECTION = 6;
+    private static final int EDEN_SIZE_AFTER_COLLECTION = 7;
+    private static final int SURVIVOR_OCCUPANCY_BEFORE_COLLECTION = 8;
+    private static final int SURVIVOR_OCCUPANCY_AFTER_COLLECTION = 9;
+    private static final int SURVIVOR_SIZE_BEFORE_COLLECTION = 10;
+    private static final int SURVIVOR_SIZE_AFTER_COLLECTION = 11;
+    private static final int YOUNG_OCCUPANCY_BEFORE_COLLECTION = 12;
+    private static final int YOUNG_OCCUPANCY_AFTER_COLLECTION = 13;
+    private static final int YOUNG_SIZE_BEFORE_COLLECTION = 14;
+    private static final int YOUNG__SIZE_AFTER_COLLECTION = 15;
+    private static final int OLD_OCCUPANCY_BEFORE_COLLECTION = 16;
+    private static final int OLD_OCCUPANCY_AFTER_COLLECTION = 17;
+    private static final int OLD_SIZE_BEFORE_COLLECTION = 18;
+    private static final int OLD_SIZE_AFTER_COLLECTION = 19;
+    private static final int HUMONGOUS_OCCUPANCY_BEFORE_COLLECTION = 20;
+    private static final int HUMONGOUS_OCCUPANCY_AFTER_COLLECTION = 21;
+    private static final int HUMONGOUS_SIZE_BEFORE_COLLECTION = 22;
+    private static final int HUMONGOUS_SIZE_AFTER_COLLECTION = 23;
+    private static final int METASPACE_OCCUPANCY_BEFORE_COLLECTION = 24;
+    private static final int METASPACE_OCCUPANCY_AFTER_COLLECTION = 25;
+    private static final int METASPACE_SIZE_BEFORE_COLLECTION = 26;
+    private static final int METASPACE_SIZE_AFTER_COLLECTION = 27;
+    private static final int METASPACE_COMMITTED_BEFORE_COLLECTION = 28;
+    private static final int METASPACE_COMMITTED_AFTER_COLLECTION = 29;
+    private static final int METASPACE_RESERVED_BEFORE_COLLECTION = 30;
+    private static final int METASPACE_RESERVED_AFTER_COLLECTION = 31;
+    private static final int CLASSSPACE_OCCUPANCY_BEFORE_COLLECTION = 32;
+    private static final int CLASSSPACE_OCCUPANCY_AFTER_COLLECTION = 33;
+    private static final int CLASSSPACE_SIZE_BEFORE_COLLECTION = 34;
+    private static final int CLASSSPACE_SIZE_AFTER_COLLECTION = 35;
+    private static final int CLASSSPACE_COMMITTED_BEFORE_COLLECTION = 36;
+    private static final int CLASSSPACE_COMMITTED_AFTER_COLLECTION = 37;
+    private static final int CLASSSPACE_RESERVED_BEFORE_COLLECTION = 38;
+    private static final int CLASSSPACE_RESERVED_AFTER_COLLECTION = 39;
 
     private final long[] memoryPoolMeasurment = {
             -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L,
@@ -324,12 +324,12 @@ public class G1GCForwardReference extends ForwardReference {
 
     // ******
     // Reference processing
-    final static int SOFT_REFERENCE = 0;
-    final static int WEAK_REFERENCE = 1;
-    final static int PHANTOM_REFERENCE = 2;
-    final static int FINAL_REFERENCE = 3;
-    final static int JNI_WEAK_REFERENCE = 4;
-    final static int CLEANER_REFERENCE = 5;
+    static final int SOFT_REFERENCE = 0;
+    static final int WEAK_REFERENCE = 1;
+    static final int PHANTOM_REFERENCE = 2;
+    static final int FINAL_REFERENCE = 3;
+    static final int JNI_WEAK_REFERENCE = 4;
+    static final int CLEANER_REFERENCE = 5;
     private double[] referenceProcessingDuarations = {-1.0d, -1.0d, -1.0d, -1.0d, -1.0d, -1.0d};
     private int[] referenceCounts = {-1, -1, -1, -1, -1, -1};
 
@@ -381,12 +381,12 @@ public class G1GCForwardReference extends ForwardReference {
 
     // ****
     // Young phases
-    private final static double NOT_SET = -1.0d;
+    private static final double NOT_SET = -1.0d;
 
-    public final static int PRE_EVACUATE_COLLECTION_SET = 0;
-    public final static int EVACUATE_COLLECTION_SET = 1;
-    public final static int POST_EVACUATE_COLLECTION_SET = 2;
-    public final static int OTHER = 3;
+    public static final int PRE_EVACUATE_COLLECTION_SET = 0;
+    public static final int EVACUATE_COLLECTION_SET = 1;
+    public static final int POST_EVACUATE_COLLECTION_SET = 2;
+    public static final int OTHER = 3;
 
     private final double[] youngCollectionPhases = {NOT_SET, NOT_SET, NOT_SET, NOT_SET};
     private final Map<String, Double> preEvacuateCSetPhaseDurations = new ConcurrentHashMap<>(3);
@@ -536,14 +536,14 @@ public class G1GCForwardReference extends ForwardReference {
     }
 
     /*
-        private final static int METASPACE_OCCUPANCY_BEFORE_COLLECTION = 24;
-    private final static int METASPACE_OCCUPANCY_AFTER_COLLECTION = 25;
-    private final static int METASPACE_SIZE_BEFORE_COLLECTION = 26;
-    private final static int METASPACE_SIZE_AFTER_COLLECTION = 27;
-    private final static int METASPACE_COMMITTED_BEFORE_COLLECTION = 28;
-    private final static int METASPACE_COMMITTED_AFTER_COLLECTION = 29;
-    private final static int METASPACE_RESERVED_BEFORE_COLLECTION = 30;
-    private final static int METASPACE_RESERVED_AFTER_COLLECTION = 31;
+    private static final int METASPACE_OCCUPANCY_BEFORE_COLLECTION = 24;
+    private static final int METASPACE_OCCUPANCY_AFTER_COLLECTION = 25;
+    private static final int METASPACE_SIZE_BEFORE_COLLECTION = 26;
+    private static final int METASPACE_SIZE_AFTER_COLLECTION = 27;
+    private static final int METASPACE_COMMITTED_BEFORE_COLLECTION = 28;
+    private static final int METASPACE_COMMITTED_AFTER_COLLECTION = 29;
+    private static final int METASPACE_RESERVED_BEFORE_COLLECTION = 30;
+    private static final int METASPACE_RESERVED_AFTER_COLLECTION = 31;
      */
     private void fillInMetaspaceStats(G1GCPauseEvent collection) {
         collection.addPermOrMetaSpaceRecord(getMemoryPoolSummary(METASPACE_OCCUPANCY_BEFORE_COLLECTION));

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCPatterns.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCPatterns.java
@@ -198,8 +198,8 @@ public interface G1GCPatterns extends G1GCTokens {
 
     //Pre 1.7.0_40 records
 
-    //final public GCParseRule STATS_INT_170PRE40 = new GCParseRule("STATS_INT_170PRE40", "Sum: " + COUNTER + ", Avg: " + COUNTER + ", Min: " + COUNTER + ", Max: " + COUNTER + ", Diff: " + COUNTER + "\\]");
-    //final public GCParseRule STATS_REAL_170PRE40 = new GCParseRule("STATS_REAL_170PRE40", "Avg:\\s+" + REAL_VALUE + ", Min:\\s+" + REAL_VALUE + ", Max:\\s+" + REAL_VALUE + ", Diff:\\s+" + REAL_VALUE);
+    //public final GCParseRule STATS_INT_170PRE40 = new GCParseRule("STATS_INT_170PRE40", "Sum: " + COUNTER + ", Avg: " + COUNTER + ", Min: " + COUNTER + ", Max: " + COUNTER + ", Diff: " + COUNTER + "\\]");
+    //public final GCParseRule STATS_REAL_170PRE40 = new GCParseRule("STATS_REAL_170PRE40", "Avg:\\s+" + REAL_VALUE + ", Min:\\s+" + REAL_VALUE + ", Max:\\s+" + REAL_VALUE + ", Diff:\\s+" + REAL_VALUE);
 
     //[Termination Attempts : 1 1 1 1 1 1 1 1 1 1 1 1
     //GCParseRule TERMINATION_ATTEMPTS_PRE17040 = new GCParseRule("TERMINATION_ATTEMPTS_PRE17040", "\\[Termination Attempts : " + INTEGER);

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogParser.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogParser.java
@@ -41,7 +41,7 @@ public abstract class GCLogParser implements SharedPatterns {
 
     public abstract String getName();
 
-    abstract protected void process(String trace);
+    protected abstract void process(String trace);
 
     abstract void advanceClock(String record);
 
@@ -49,7 +49,7 @@ public abstract class GCLogParser implements SharedPatterns {
      * The assumption is, this method will manage the global clock and thus should never be over ridden
      * @param now - DateTimeStamp from the current GC log record
      */
-    final protected void advanceClock(DateTimeStamp now) {
+    protected final void advanceClock(DateTimeStamp now) {
         if (now == null)
             return;
             // now can be the same but it can't be less than

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/GCParseRule.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/GCParseRule.java
@@ -11,8 +11,8 @@ import java.util.regex.Pattern;
  */
 public class GCParseRule {
 
-    final private String name;
-    final private Pattern pattern;
+    private final String name;
+    private final Pattern pattern;
 
     public GCParseRule(String name, String pattern) {
         this.name = name;

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
@@ -90,7 +90,7 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
      */
 
 
-    final private MRUQueue<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
+    private final MRUQueue<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
 
     {
         parseRules = new MRUQueue<>();
@@ -539,8 +539,8 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
     }
 
     //46.435: [GC 46.435: [ParNew: 19136K->19136K(19136K), 0.0000274 secs]46.435: [CMS46.458: [CMS-concurrent-sweep: 0.060/0.117 secs] [Times: user=0.21 sys=0.01, real=0.12 secs]
-    //final static public ParseRule PARNEW_CONCURRENT_MODE_END = new ParseRule (GC_PREFIX + PARNEW_BLOCK + TIMESTAMP + "\\[CMS" + CMS_PHASE_END + "(?: " + CPU_BREAKDOWN + ")?$");
-    //final static public String CMS_PHASE_END = DATE_TIMESTAMP + "\\[CMS-concurrent-(.+): " + CPU_WALLCLOCK + "\\]";
+    //public static final ParseRule PARNEW_CONCURRENT_MODE_END = new ParseRule (GC_PREFIX + PARNEW_BLOCK + TIMESTAMP + "\\[CMS" + CMS_PHASE_END + "(?: " + CPU_BREAKDOWN + ")?$");
+    //public static final String CMS_PHASE_END = DATE_TIMESTAMP + "\\[CMS-concurrent-(.+): " + CPU_WALLCLOCK + "\\]";
     public void parNewConcurrentModeEnd(GCLogTrace trace, String line) {
         garbageCollectionTypeForwardReference = GarbageCollectionTypes.ParNew;
         scavengeTimeStamp = getClock();

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/JVMEventParser.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/JVMEventParser.java
@@ -120,7 +120,7 @@ public class JVMEventParser extends PreUnifiedGCLogParser implements JVMPatterns
         safePoints.clear();
     }
 
-    private static abstract class SafePointData {
+    private abstract static class SafePointData {
         double duration;
 
         abstract JVMEvent complete(DateTimeStamp timeStamp1);

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ParNewSerial.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ParNewSerial.java
@@ -8,82 +8,82 @@ package com.microsoft.gctoolkit.parser;
 public interface ParNewSerial extends PreUnifiedTokens {
 
     //12.008: [GC 12.008: [ParNew: 4680K->224K(4992K), 0.0009052 secs]12.009: [Tenured: 11421K->7456K(11448K), 0.0679043 secs] 15860K->7456K(16440K), [Perm : 10677K->10677K(21248K)], 0.0689327 secs] [Times: user=0.07 sys=0.00, real=0.07 secs]
-//    final static public Pattern PARNEW_SERIAL_FULL = Pattern.compile( DATE_TIMESTAMP + "\\[GC " + PARNEW_BLOCK + TENURED_BLOCK + " " + BEFORE_AFTER_CONFIGURED + ", " + PERM_RECORD + ", " + PAUSE_TIME);
+//    public static final Pattern PARNEW_SERIAL_FULL = Pattern.compile( DATE_TIMESTAMP + "\\[GC " + PARNEW_BLOCK + TENURED_BLOCK + " " + BEFORE_AFTER_CONFIGURED + ", " + PERM_RECORD + ", " + PAUSE_TIME);
 
     //: 7077K->86K(7552K), 0.0019757 secs]20.774: [Tenured: 17007K->7966K(17080K), 0.0754072 secs] 23865K->7966K(24632K), [Perm : 10697K->10697K(21248K)], 0.0776402 secs]
     //]20.774: [Tenured: 17007K->7966K(17080K), 0.0754072 secs] 23865K->7966K(24632K), [Perm : 10697K->10697K(21248K)], 0.0776402 secs]
-//    final static public Pattern PARNEW_SERIAL_FULL_SPLIT = Pattern.compile( "^: " + BEFORE_AFTER_CONFIGURED_PAUSE + "\\]" + TENURED_BLOCK + " " + BEFORE_AFTER_CONFIGURED + ", " + PERM_RECORD + ", " + PAUSE_TIME);
+//    public static final Pattern PARNEW_SERIAL_FULL_SPLIT = Pattern.compile( "^: " + BEFORE_AFTER_CONFIGURED_PAUSE + "\\]" + TENURED_BLOCK + " " + BEFORE_AFTER_CONFIGURED + ", " + PERM_RECORD + ", " + PAUSE_TIME);
 
 /*
 
-    final static public Pattern PAR_OLD_REDUCTION = Pattern.compile("\\[ParOldGen: " + FROM_TO_CONFIGURED + "\\]");
+    public static final Pattern PAR_OLD_REDUCTION = Pattern.compile("\\[ParOldGen: " + FROM_TO_CONFIGURED + "\\]");
     
-    final static public String  TENURED_AND_PERM_REDUCTION =    TIMESTAMP + ": \\[Tenured: " + FROM_TO_CONFIGURED_PAUSE + "\\] ?" + FROM_TO_CONFIGURED + ", " + PERM_REDUCTION    + ", " + PAUSE_TIME + "\\]";
-    final static public String  TENURED_AND_NO_PERM_REDUCTION = TIMESTAMP + ": \\[Tenured: " + FROM_TO_CONFIGURED_PAUSE + "\\] ?" + FROM_TO_CONFIGURED + ", " + PERM_NO_REDUCTION + ", " + PAUSE_TIME + "\\]";
+    public static final String  TENURED_AND_PERM_REDUCTION =    TIMESTAMP + ": \\[Tenured: " + FROM_TO_CONFIGURED_PAUSE + "\\] ?" + FROM_TO_CONFIGURED + ", " + PERM_REDUCTION    + ", " + PAUSE_TIME + "\\]";
+    public static final String  TENURED_AND_NO_PERM_REDUCTION = TIMESTAMP + ": \\[Tenured: " + FROM_TO_CONFIGURED_PAUSE + "\\] ?" + FROM_TO_CONFIGURED + ", " + PERM_NO_REDUCTION + ", " + PAUSE_TIME + "\\]";
 
     //2.783: [Full GC 2.783: [Tenured: 2684K->3969K(8192K), 0.0569037 secs] 4603K->3969K(13696K), [Perm : 16382K->16382K(16384K)], 0.0569750 secs]
-    final static public Pattern PARALLEL_OLD_PERM_REDUCTION = Pattern.compile("\\[Full GC " + TIMESTAMP + ": \\[Tenured: " + FROM_TO_CONFIGURED + ", " + PAUSE_TIME + "\\] " + FROM_TO_CONFIGURED + ", " + PERM_REDUCTION.toString() + ", " + PAUSE_TIME + "\\]");
-    final static public Pattern PARALLEL_OLD_NO_PERM_REDUCTION = Pattern.compile("\\[Full GC " + TIMESTAMP + ": \\[Tenured: " + FROM_TO_CONFIGURED + ", " + PAUSE_TIME + "\\] " + FROM_TO_CONFIGURED + ", " + PERM_NO_REDUCTION.toString() + ", " + PAUSE_TIME + "\\]");
+    public static final Pattern PARALLEL_OLD_PERM_REDUCTION = Pattern.compile("\\[Full GC " + TIMESTAMP + ": \\[Tenured: " + FROM_TO_CONFIGURED + ", " + PAUSE_TIME + "\\] " + FROM_TO_CONFIGURED + ", " + PERM_REDUCTION.toString() + ", " + PAUSE_TIME + "\\]");
+    public static final Pattern PARALLEL_OLD_NO_PERM_REDUCTION = Pattern.compile("\\[Full GC " + TIMESTAMP + ": \\[Tenured: " + FROM_TO_CONFIGURED + ", " + PAUSE_TIME + "\\] " + FROM_TO_CONFIGURED + ", " + PERM_NO_REDUCTION.toString() + ", " + PAUSE_TIME + "\\]");
 
     //TODO
     //0.963: [ParNew: 16256K->1984K(18240K), 0.0689940 secs] 16256K->6122K(58752K), 0.0691170 secs]
-    final public static Pattern PARNEW = Pattern.compile( "\\[ParNew: " + FROM_TO_CONFIGURED_PAUSE + "\\] " + FROM_TO_CONFIGURED_PAUSE + "\\]");
-    final public static Pattern PARNEW_ICMS = Pattern.compile("\\[ParNew: " + FROM_TO_CONFIGURED_PAUSE + "\\] " + FROM_TO_CONFIGURED + CMSPatterns.ICMS_DC + ", " + PAUSE_TIME + "\\]");
+    public static final Pattern PARNEW = Pattern.compile( "\\[ParNew: " + FROM_TO_CONFIGURED_PAUSE + "\\] " + FROM_TO_CONFIGURED_PAUSE + "\\]");
+    public static final Pattern PARNEW_ICMS = Pattern.compile("\\[ParNew: " + FROM_TO_CONFIGURED_PAUSE + "\\] " + FROM_TO_CONFIGURED + CMSPatterns.ICMS_DC + ", " + PAUSE_TIME + "\\]");
 
     //25.118: [GC 25.118: [ParNew: 1258368K->143985K(1415616K), 0.0987560 secs] 1265723K->151341K(8231360K), 0.0989880 secs] [Times: user=0.96 sys=0.49, real=0.09 secs]
-    final public static Pattern PARNEW_COMPLETE = Pattern.compile( START_OF_GC_TIMESTAMP + "\\[GC\\s*" + GC_TIMESTAMP + PARNEW);
+    public static final Pattern PARNEW_COMPLETE = Pattern.compile( START_OF_GC_TIMESTAMP + "\\[GC\\s*" + GC_TIMESTAMP + PARNEW);
 
     //25.030: [GC 25.030: [ParNew: 451942K->51072K(460096K), 1.7048460 secs] 451942K->115934K(12531840K) icms_dc=5 , 1.7050420 secs]
-    final public static Pattern PARNEW_COMPLETE_ICMS = Pattern.compile( START_OF_GC_TIMESTAMP + "\\[GC\\s*" + GC_TIMESTAMP + PARNEW_ICMS);
-    final public static Pattern PARNEW_PRINT_HEAP_AT_GC = Pattern.compile( START_OF_GC_TIMESTAMP + "\\[ParNew: " + FROM_TO_CONFIGURED_PAUSE + "\\]" + FROM_TO_CONFIGURED + "Heap after GC invocations=");
-    final public static Pattern PARNEW_PRINT_HEAP_AT_GC_PAUSE_TIME = Pattern.compile( "} , " + TIMESTAMP + "]");
+    public static final Pattern PARNEW_COMPLETE_ICMS = Pattern.compile( START_OF_GC_TIMESTAMP + "\\[GC\\s*" + GC_TIMESTAMP + PARNEW_ICMS);
+    public static final Pattern PARNEW_PRINT_HEAP_AT_GC = Pattern.compile( START_OF_GC_TIMESTAMP + "\\[ParNew: " + FROM_TO_CONFIGURED_PAUSE + "\\]" + FROM_TO_CONFIGURED + "Heap after GC invocations=");
+    public static final Pattern PARNEW_PRINT_HEAP_AT_GC_PAUSE_TIME = Pattern.compile( "} , " + TIMESTAMP + "]");
 
 
     //939.183: [GC [PSYoungGen: 523744K->844K(547584K)] 657668K->135357K(1035008K), 0.0157986 secs] [Times: user=0.30 sys=0.01, real=0.02 secs]
-    final public static Pattern PSYOUNGGEN_COMPLETE = Pattern.compile("\\[GC \\[PSYoungGen: " + FROM_TO_CONFIGURED + "\\] " + FROM_TO_CONFIGURED_PAUSE + "\\]");
+    public static final Pattern PSYOUNGGEN_COMPLETE = Pattern.compile("\\[GC \\[PSYoungGen: " + FROM_TO_CONFIGURED + "\\] " + FROM_TO_CONFIGURED_PAUSE + "\\]");
 
     //Tenuring records
     //Desired survivor size 107347968 bytes, new threshold 1 (max 4)
-    final public static Pattern TENURING_SUMMARY = Pattern.compile("Desired survivor size (\\d+) bytes, new threshold (\\d+) \\(max (\\d+)\\)");
-    final public static Pattern TENURING_AGE_BREAKDOWN = Pattern.compile("- age\\s+(\\d+):\\s+(\\d+) bytes,\\s+(\\d+) total");
+    public static final Pattern TENURING_SUMMARY = Pattern.compile("Desired survivor size (\\d+) bytes, new threshold (\\d+) \\(max (\\d+)\\)");
+    public static final Pattern TENURING_AGE_BREAKDOWN = Pattern.compile("- age\\s+(\\d+):\\s+(\\d+) bytes,\\s+(\\d+) total");
 
-    final public static Pattern YG_WITH_TENURING = Pattern.compile("\\[GC$");
-    final public static Pattern PSYOUNGGEN_DETAILS = Pattern.compile("\\[PSYoungGen: " + FROM_TO_CONFIGURED + "\\] " +  FROM_TO_CONFIGURED_PAUSE + "\\]");
-    final public static Pattern PS_FULL_GC_DETAILS = Pattern.compile("\\[Full GC \\[PSYoungGen:");
+    public static final Pattern YG_WITH_TENURING = Pattern.compile("\\[GC$");
+    public static final Pattern PSYOUNGGEN_DETAILS = Pattern.compile("\\[PSYoungGen: " + FROM_TO_CONFIGURED + "\\] " +  FROM_TO_CONFIGURED_PAUSE + "\\]");
+    public static final Pattern PS_FULL_GC_DETAILS = Pattern.compile("\\[Full GC \\[PSYoungGen:");
 
-    final public static Pattern PS_FULL_WITH_UNLOADING = Pattern.compile("\\[Full GC\\[Unloading");
-    final public static Pattern PS_FULL_WITH_UNLOADING_SYSTEM = Pattern.compile("\\[Full GC \\(System\\)\\[Unloading");
+    public static final Pattern PS_FULL_WITH_UNLOADING = Pattern.compile("\\[Full GC\\[Unloading");
+    public static final Pattern PS_FULL_WITH_UNLOADING_SYSTEM = Pattern.compile("\\[Full GC \\(System\\)\\[Unloading");
 
     //0.465: [GC 0.465: [DefNew: 17217K->17217K(19328K), 0.0000096 secs]0.465: [Tenured: 36555K->11838K(43008K), 0.0266298 secs] 53772K->11838K(62336K), [Perm : 2819K->2819K(21248K)], 0.0775828 secs]
-    final public static Pattern DEFNEW_TENURED = Pattern.compile("\\[GC\\s*" + GC_TIMESTAMP + "\\[DefNew: .+ \\[Tenured:");
+    public static final Pattern DEFNEW_TENURED = Pattern.compile("\\[GC\\s*" + GC_TIMESTAMP + "\\[DefNew: .+ \\[Tenured:");
 
     //: 4806K->1427K(5504K), 0.0089964 secs]4.690: [Tenured: 8890K->8960K(8960K), 0.0683118 secs] 12365K->10317K(14464K), [Perm : 18543K->18543K(18688K)], 0.0775077 secs]
-    final public static Pattern DEFNEW_TRIGGERED_FULL = Pattern.compile( "^: " + FROM_TO_CONFIGURED + ", .+ secs\\]" + TIMESTAMP + ": \\[Tenured:");
-    final public static Pattern DEFNEW_TRIGGERED_FULL_PERMSWEEP = Pattern.compile( "^: " + FROM_TO_CONFIGURED + ", .+ secs\\]" + TENURED_AND_PERM_REDUCTION);
-    final public static Pattern DEFNEW_TRIGGERED_FULL_PERMNOSWEEP = Pattern.compile( "^: " + FROM_TO_CONFIGURED + ", .+ secs\\]" + TENURED_AND_NO_PERM_REDUCTION);
+    public static final Pattern DEFNEW_TRIGGERED_FULL = Pattern.compile( "^: " + FROM_TO_CONFIGURED + ", .+ secs\\]" + TIMESTAMP + ": \\[Tenured:");
+    public static final Pattern DEFNEW_TRIGGERED_FULL_PERMSWEEP = Pattern.compile( "^: " + FROM_TO_CONFIGURED + ", .+ secs\\]" + TENURED_AND_PERM_REDUCTION);
+    public static final Pattern DEFNEW_TRIGGERED_FULL_PERMNOSWEEP = Pattern.compile( "^: " + FROM_TO_CONFIGURED + ", .+ secs\\]" + TENURED_AND_NO_PERM_REDUCTION);
 
     // 83.940: [Full GC 83.940: [Tenured: 75938K->76927K(126568K), 1.8452680 secs] 106725K->76927K(183592K), [Perm : 62463K->62463K(62464K)], 1.8454850 secs] [Times: user=1.84 sys=0.01, real=1.85 secs] 
-    final public static Pattern SERIAL_FULL_SYSTEM = Pattern.compile("\\[Full GC \\(System\\) " + TENURED_AND_PERM_REDUCTION);
+    public static final Pattern SERIAL_FULL_SYSTEM = Pattern.compile("\\[Full GC \\(System\\) " + TENURED_AND_PERM_REDUCTION);
     
     //104401.329: [Full GC (System) [PSYoungGen: 0K->0K(524224K)] [PSFull: 4928117K->4928117K(20447232K)] 4928117K->4928117K(20971456K) [PSPermGen: 113238K->113238K(262144K)], 1.7623490 secs]
-    final public static Pattern PS_FULL_SYSTEM = Pattern.compile("\\[Full GC \\(System\\) \\[PSYoungGen:");
+    public static final Pattern PS_FULL_SYSTEM = Pattern.compile("\\[Full GC \\(System\\) \\[PSYoungGen:");
 
-    final public static Pattern PS_FULL = Pattern.compile("\\[Full GC \\[PSYoungGen:");
+    public static final Pattern PS_FULL = Pattern.compile("\\[Full GC \\[PSYoungGen:");
     
     //12525.344: [Full GC 12525.344: [ParNew
-    final public static Pattern PARNEW_FULL_FOLLOWED_BY_DETAILS = Pattern.compile("\\[Full GC " + TIMESTAMP + ": \\[ParNew$");
+    public static final Pattern PARNEW_FULL_FOLLOWED_BY_DETAILS = Pattern.compile("\\[Full GC " + TIMESTAMP + ": \\[ParNew$");
     
 
     // 93733.352: [Full GC[Unloading class sun.reflect.GeneratedMethodAccessor3]
     // [PSYoungGen: 892029K->0K(1034432K)] [ParOldGen: 7324875K->5037686K(7340032K)] 8216904K->5037686K(8374464K) [PSPermGen: 54404K->54363K(122496K)], 10.6791310 secs] [Times: user=67.94 sys=0.11, real=10.68 secs] 
-    final public static Pattern PAR_FULL_GC_WITH_CLASS_UNLOADING = Pattern.compile(PAR_OLD_REDUCTION + " " + FROM_TO_CONFIGURED + ".* " + PAUSE_TIME);
+    public static final Pattern PAR_FULL_GC_WITH_CLASS_UNLOADING = Pattern.compile(PAR_OLD_REDUCTION + " " + FROM_TO_CONFIGURED + ".* " + PAUSE_TIME);
 
     //[PSPermGen: 7034K->7034K(21248K)]
-    final public static Pattern PS_PERM_GEN = Pattern.compile( "\\[PSPermGen: [0-9]+K->[0-9]+K\\([0-9]+K\\)\\]");
+    public static final Pattern PS_PERM_GEN = Pattern.compile( "\\[PSPermGen: [0-9]+K->[0-9]+K\\([0-9]+K\\)\\]");
     
     //: 4806K->1427K(5504K), 0.0089964 secs]4.690: [Tenured: 8890K->8960K(8960K), 0.0683118 secs] 12365K->10317K(14464K), [Perm : 18543K->18543K(18688K)], 0.0775077 secs]
-    final static public Pattern TENURED_DETAILS_PERM_REDUCTION = Pattern.compile(": " + FROM_TO_CONFIGURED_PAUSE + "\\]" + TENURED_AND_PERM_REDUCTION);
-    final static public Pattern TENURED_DETAILS_NO_PERM_REDUCTION = Pattern.compile( ": " + FROM_TO_CONFIGURED_PAUSE + "\\]" + TENURED_AND_NO_PERM_REDUCTION);
+    public static final Pattern TENURED_DETAILS_PERM_REDUCTION = Pattern.compile(": " + FROM_TO_CONFIGURED_PAUSE + "\\]" + TENURED_AND_PERM_REDUCTION);
+    public static final Pattern TENURED_DETAILS_NO_PERM_REDUCTION = Pattern.compile( ": " + FROM_TO_CONFIGURED_PAUSE + "\\]" + TENURED_AND_NO_PERM_REDUCTION);
 
 */
 

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/PreUnifiedG1GCParser.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/PreUnifiedG1GCParser.java
@@ -68,7 +68,7 @@ public class PreUnifiedG1GCParser extends PreUnifiedGCLogParser implements G1GCP
     private GarbageCollectionTypes concurrentCollectionTypeForwardReference;
     private final ConcurrentLinkedQueue<JVMEvent> backlog = new ConcurrentLinkedQueue<>();
 
-    final private MRUQueue<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
+    private final MRUQueue<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
 
     {
         parseRules = new MRUQueue<>();

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/SafepointParseRule.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/SafepointParseRule.java
@@ -21,7 +21,7 @@ public class SafepointParseRule {
     private static final ConcurrentMap<SafepointParseRule, AtomicInteger> misses = new ConcurrentHashMap<>();
     private static final ConcurrentMap<SafepointParseRule, Throwable> origin = new ConcurrentHashMap<>();
 
-    final private Pattern pattern;
+    private final Pattern pattern;
 
     public SafepointParseRule(String pattern) {
         this.pattern = Pattern.compile(pattern);

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ShenandoahParser.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ShenandoahParser.java
@@ -33,7 +33,7 @@ public class ShenandoahParser extends UnifiedGCLogParser implements ShenandoahPa
     private final boolean debugging = ("true".equals(System.getProperty("microsoft.debug", "false").toLowerCase()));
     private final boolean develop = ("true".equals(System.getProperty("microsoft.develop", "false").toLowerCase()));
 
-    final private MRUQueue<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
+    private final MRUQueue<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
 
     {
         parseRules = new MRUQueue<>();

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -51,7 +51,7 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
     private G1GCForwardReference forwardReference;
     private boolean concurrentPhaseActive = false;
 
-    final private RuleSet<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
+    private final RuleSet<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
 
     {
         parseRules = new RuleSet<>();

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
@@ -39,7 +39,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     private final boolean debugging = ("true".equals(System.getProperty("microsoft.debug", "false").toLowerCase()));
     private final boolean develop = ("true".equals(System.getProperty("microsoft.develop", "false").toLowerCase()));
 
-    final private MRUQueue<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
+    private final MRUQueue<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
 
     {
         parseRules = new MRUQueue<>();

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/Decorators.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/Decorators.java
@@ -20,10 +20,10 @@ import java.util.stream.Collectors;
 
 public class Decorators {
 
-    private final static Logger LOGGER = Logger.getLogger(Decorators.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(Decorators.class.getName());
 
-    private final static long TWENTY_YEARS_IN_MILLIS = 731L * 24L * 60L * 60L * 1000L;
-    private final static long TWENTY_YEARS_IN_NANO = 731L * 24L * 60L * 60L * 1000L;
+    private static final long TWENTY_YEARS_IN_MILLIS = 731L * 24L * 60L * 60L * 1000L;
+    private static final long TWENTY_YEARS_IN_NANO = 731L * 24L * 60L * 60L * 1000L;
 
     private Matcher decorators = null;
     private List<String> tags = new ArrayList<>();
@@ -58,7 +58,7 @@ public class Decorators {
     }
 
     // For some reason, ISO_DATE_TIME doesn't like that time-zone is -0100. It wants -01:00.
-    private final static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
     public ZonedDateTime getDateStamp() {
         try {

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/PreUnifiedJVMConfiguration.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/PreUnifiedJVMConfiguration.java
@@ -90,12 +90,12 @@ public class PreUnifiedJVMConfiguration implements SimplePatterns, CMSPatterns, 
     private static final int MAXIMUM_LINES_TO_EXAMINE = 10_000; // duplicated in UnifedJVMConfiguration
     private int lineCount = MAXIMUM_LINES_TO_EXAMINE;
 
-    final static private GCParseRule TENURED_BLOCK = new GCParseRule("TENURED_BLOCK", "\\[Tenured: \\d+K->\\d+K\\(\\d+K\\), \\d+[.|,]\\d{7} secs\\]");
-    final static private GCParseRule PREFIX = new GCParseRule("PREFIX", PreUnifiedTokens.GC_PREFIX);
-    final static private GCParseRule FULL_PREFIX = new GCParseRule("FULL_PREFIX", PreUnifiedTokens.FULL_GC_PREFIX);
-    final static private GCParseRule G1GC_PREFIX = new GCParseRule("G1GC_PREFIX", G1GCTokens.G1GC_PREFIX);
-    final static private GCParseRule REFERENCE_PROCESSING_BLOCK = new GCParseRule("REFERENCE_PROCESSING_BLOCK", PreUnifiedTokens.REFERENCE_RECORDS);
-    final static private Pattern excludeG1Ergonomics = Pattern.compile("^\\d+(\\.|,)\\d+: \\[G1Ergonomics");
+    private static final GCParseRule TENURED_BLOCK = new GCParseRule("TENURED_BLOCK", "\\[Tenured: \\d+K->\\d+K\\(\\d+K\\), \\d+[.|,]\\d{7} secs\\]");
+    private static final GCParseRule PREFIX = new GCParseRule("PREFIX", PreUnifiedTokens.GC_PREFIX);
+    private static final GCParseRule FULL_PREFIX = new GCParseRule("FULL_PREFIX", PreUnifiedTokens.FULL_GC_PREFIX);
+    private static final GCParseRule G1GC_PREFIX = new GCParseRule("G1GC_PREFIX", G1GCTokens.G1GC_PREFIX);
+    private static final GCParseRule REFERENCE_PROCESSING_BLOCK = new GCParseRule("REFERENCE_PROCESSING_BLOCK", PreUnifiedTokens.REFERENCE_RECORDS);
+    private static final Pattern excludeG1Ergonomics = Pattern.compile("^\\d+(\\.|,)\\d+: \\[G1Ergonomics");
 
 
     private final LoggingDiary diary;
@@ -450,7 +450,7 @@ public class PreUnifiedJVMConfiguration implements SimplePatterns, CMSPatterns, 
             getDiary().setTrue(SupportedFlags.SERIAL);
 
             getDiary().setTrue(SupportedFlags.GC_DETAILS);
-            //todo: final private int SupportedFlags.GC_CAUSE = 12;
+            //todo: private final int SupportedFlags.GC_CAUSE = 12;
             getDiary().setFalse(SupportedFlags.CMS_DEBUG_LEVEL_1);
             if (line.contains("Metaspace")) {
                 getDiary().setFalse(SupportedFlags.JDK70);
@@ -864,7 +864,7 @@ public class PreUnifiedJVMConfiguration implements SimplePatterns, CMSPatterns, 
     }
 
     //"Java HotSpot(TM) 64-Bit Server VM (25.40-b25) for bsd-amd64 JRE (1.8.0_40-b25), built on Feb 10 2015 21:07:25 by \"java_re\" with gcc 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)",
-    static private final Pattern VERSION = Pattern.compile("(1)\\.([6-9])\\.0(_\\d*)?");
+    private static final Pattern VERSION = Pattern.compile("(1)\\.([6-9])\\.0(_\\d*)?");
 
     private void parseJVMVersion(String versionString) {
         Matcher matcher = VERSION.matcher(versionString);

--- a/core/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/UnifiedLoggingCMSPatterns.java
+++ b/core/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/UnifiedLoggingCMSPatterns.java
@@ -15,14 +15,14 @@ public interface UnifiedLoggingCMSPatterns extends UnifiedLoggingTokens {
 [1.169s][info   ][gc,cpu      ] GC(0) User=4.60s Sys=0.26s Real=0.92s
      */
 
-//    public final static String DECIMAL_POINT = "(?:\\.|,)";
-//    public final static String INTEGER = "\\d+";
-//    public final static String REAL_NUMBER = INTEGER + DECIMAL_POINT + INTEGER;
-//    public final static String PERCENTAGE = REAL_NUMBER + "\\s?%";
-//    public final static String COUNTER = "(" + INTEGER +")";
-//    public final static String TIME = REAL_NUMBER + "s";
-//    public final static String LOG_LEVEL= "(debug|info|warning|fine|finest)";
-//    public final static String TAG = "(\\w+),?";
+//    public static final String DECIMAL_POINT = "(?:\\.|,)";
+//    public static final String INTEGER = "\\d+";
+//    public static final String REAL_NUMBER = INTEGER + DECIMAL_POINT + INTEGER;
+//    public static final String PERCENTAGE = REAL_NUMBER + "\\s?%";
+//    public static final String COUNTER = "(" + INTEGER +")";
+//    public static final String TIME = REAL_NUMBER + "s";
+//    public static final String LOG_LEVEL= "(debug|info|warning|fine|finest)";
+//    public static final String TAG = "(\\w+),?";
 
     /*
 [0.165s][info ][gc,start     ] GC(1) Pause Young (Allocation Failure)

--- a/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/ShenandoahParserRulesTest.java
+++ b/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/ShenandoahParserRulesTest.java
@@ -88,7 +88,7 @@ public class ShenandoahParserRulesTest implements ShenandoahPatterns {
             REFERENCE
     };
 
-    private final static String[][] lines = {
+    private static final String[][] lines = {
             {  //   0
                     "[31.818s][info][gc,start      ] GC(7) Concurrent reset",
                     "[31.953s][info][gc            ] GC(7) Concurrent reset 134.638ms",

--- a/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/TestLogFile.java
+++ b/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/TestLogFile.java
@@ -13,7 +13,7 @@ public class TestLogFile {
 
     private final File logFile;
 
-    private final static String[] relativePaths = {
+    private static final String[] relativePaths = {
             "./",
             "preunified/",
             "preunified/cms/parnew/details/tenuring/",

--- a/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/UnifiedGenerationalParserRulesTest.java
+++ b/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/UnifiedGenerationalParserRulesTest.java
@@ -60,7 +60,7 @@ public class UnifiedGenerationalParserRulesTest implements UnifiedGenerationalPa
         }
     }
 
-    private final static String PARALLEL_PHASES = "(Marking Phase|Summary Phase|Adjust Roots|Compaction Phase|Post Compact)";
+    private static final String PARALLEL_PHASES = "(Marking Phase|Summary Phase|Adjust Roots|Compaction Phase|Post Compact)";
 
     private GCParseRule[] rules = {
             YOUNG_DETAILS,                  //   0

--- a/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/diary/CommandLineFlagsLogDiaryTest.java
+++ b/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/diary/CommandLineFlagsLogDiaryTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CommandLineFlagsLogDiaryTest {
 
-    private final static String[][] gcLogFileHeader = {
+    private static final String[][] gcLogFileHeader = {
             {
                     "Java HotSpot(TM) 64-Bit Server VM (25.40-b25) for bsd-amd64 JRE (1.8.0_40-b25), built on Feb 10 2015 21:07:25 by \"java_re\" with gcc 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)",
                     "Memory: 4k page, physical 16777216k(920952k free)",

--- a/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/jvm/DecoratorsTest.java
+++ b/core/parser/src/test/java/com/microsoft/gctoolkit/parser/test/jvm/DecoratorsTest.java
@@ -28,7 +28,7 @@ public class DecoratorsTest {
     [2018-04-04T09:10:00.586-0100][0.018s][1522825800586ms][18ms][10026341461044ns][17738937ns][1375][7427][info][gc] Using G1
  */
 
-    private final static String[] decoratorsLines = {
+    private static final String[] decoratorsLines = {
             "Using G1",
             "[gc] Using G1",
             "[info][gc] Using G1",
@@ -42,7 +42,7 @@ public class DecoratorsTest {
             "[2018-04-04T09:10:00.586-0100][0.018s][1522825800586ms][18ms][10026341461044ns][17738937ns][1375][7427][info][gc] Using G1"
     };
 
-    private final static String[] decoratorsValuesTestSupport = {
+    private static final String[] decoratorsValuesTestSupport = {
             "[2018-04-04T09:10:00.586-0100][0.018s][1522825800586ms][10026341461044ns][1375][7427][info][gc] Using G1",
             "[2018-04-04T09:10:00.586-0100][0.018s][18ms][17738937ns][1375][7427][info][gc] Using G1"
     };

--- a/core/vertx/src/test/java/com/microsoft/gctoolkit/vertx/test/io/TestLogFile.java
+++ b/core/vertx/src/test/java/com/microsoft/gctoolkit/vertx/test/io/TestLogFile.java
@@ -13,7 +13,7 @@ public class TestLogFile {
 
     private final File logFile;
 
-    private final static String[] relativePaths = {
+    private static final String[] relativePaths = {
             "./",
             "preunified/",
             "preunified/cms/parnew/details/tenuring/",


### PR DESCRIPTION
"If two or more (distinct) field modifiers appear in a field declaration, it is customary, though not required, that they appear in the order consistent with that shown above in the production for FieldModifier."

In other words:

public protected private static final transient volatile

https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.3.1