### PR TITLE
Followed best practice in using fully qualified class names for uses and provides

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,13 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import com.microsoft.gctoolkit.GCToolKit;
-import com.microsoft.gctoolkit.aggregator.Aggregation;
-import com.microsoft.gctoolkit.aggregator.Aggregator;
-import com.microsoft.gctoolkit.event.jvm.JVMEvent;
-import com.microsoft.gctoolkit.io.GCLogFile;
-import com.microsoft.gctoolkit.jvm.JavaVirtualMachine;
-
 /**
  * Contains the core API for the Microsoft, Java Garbage Collection Toolkit.
  * The toolkit is a GC log parser and a framework for consuming and extracting data from
@@ -15,21 +8,22 @@ import com.microsoft.gctoolkit.jvm.JavaVirtualMachine;
  * <p>
  * The main entry points are:
  * <dl>
- * <dt>{@link GCToolKit}</dt>
+ * <dt>{@link com.microsoft.gctoolkit.GCToolKit}</dt>
  * <dd>This is the main API that an application will use.</dd>
- * <dt>{@link GCLogFile}</dt>
+ * <dt>{@link com.microsoft.gctoolkit.io.GCLogFile}</dt>
  * <dd>A GCLogFile is passed to GCToolKit for analysis.</dd>
- * <dt>{@link JavaVirtualMachine}</dt>
+ * <dt>{@link com.microsoft.gctoolkit.jvm.JavaVirtualMachine}</dt>
  * <dd>This contains the results from running an analysis on a GC log.</dd>
- * <dt>{@link JVMEvent}</dt>
+ * <dt>{@link com.microsoft.gctoolkit.event.jvm.JVMEvent}</dt>
  * <dd>The parser generates JVMEvents.</dd>
- * <dt>{@link Aggregator}</dt>
+ * <dt>{@link com.microsoft.gctoolkit.aggregator.Aggregator}</dt>
  * <dd>An Aggregator captures JVMEvents for analysis.</dd>
- * <dt>{@link Aggregation}</dt>
+ * <dt>{@link com.microsoft.gctoolkit.aggregator.Aggregation}</dt>
  * <dd>An Aggregation works with an Aggregator to collect and analyze data from JVMEvents.</dd>
  * </dl>
- * @uses JavaVirtualMachine
- * @uses Aggregator
+ *
+ * @uses com.microsoft.gctoolkit.jvm.JavaVirtualMachine
+ * @uses com.microsoft.gctoolkit.aggregator.Aggregator
  */
 module com.microsoft.gctoolkit.api {
 
@@ -47,6 +41,6 @@ module com.microsoft.gctoolkit.api {
     exports com.microsoft.gctoolkit.util.concurrent;
     requires java.logging;
 
-    uses JavaVirtualMachine;
-    uses Aggregation;
+    uses com.microsoft.gctoolkit.jvm.JavaVirtualMachine;
+    uses com.microsoft.gctoolkit.aggregator.Aggregation;
 }

--- a/sample/src/main/java/module-info.java
+++ b/sample/src/main/java/module-info.java
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import com.microsoft.gctoolkit.aggregator.Aggregation;
-import com.microsoft.gctoolkit.sample.aggregation.HeapOccupancyAfterCollectionSummary;
-
 /**
  * Contains an Aggregator and an Aggregation
  */
@@ -18,5 +15,6 @@ module com.microsoft.gctoolkit.sample {
 
     exports com.microsoft.gctoolkit.sample;
 
-    provides Aggregation with HeapOccupancyAfterCollectionSummary;
+    provides com.microsoft.gctoolkit.aggregator.Aggregation
+            with com.microsoft.gctoolkit.sample.aggregation.HeapOccupancyAfterCollectionSummary;
 }

--- a/vertx/src/main/java/module-info.java
+++ b/vertx/src/main/java/module-info.java
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import com.microsoft.gctoolkit.jvm.JavaVirtualMachine;
-import com.microsoft.gctoolkit.vertx.jvm.DefaultJavaVirtualMachine;
-
 /**
  * Contains a vertx based implementation of GCToolKit. The vertx implementation is an internal module.
  * @provides com.microsoft.gctoolkit.jvm.JavaVirtualMachine
@@ -22,7 +19,8 @@ module com.microsoft.gctoolkit.vertx {
             com.microsoft.gctoolkit.api,
             gctoolkit.vertx.test;
 
-    provides JavaVirtualMachine with DefaultJavaVirtualMachine;
+    provides com.microsoft.gctoolkit.jvm.JavaVirtualMachine
+            with com.microsoft.gctoolkit.vertx.jvm.DefaultJavaVirtualMachine;
 
     requires com.microsoft.gctoolkit.api;
     requires com.microsoft.gctoolkit.parser;


### PR DESCRIPTION
Best practice according to "Java 9 Modularity" Mak & Bakker, as well as in the OpenJDK is to use fully qualified class names in the "uses" and "provides" clauses inside module-info.java. Thus com.microsoft.gctoolkit.jvm.JavaVirtualMachine instead of using an import and then JavaVirtualMachine. Jetty does not do it this way BTW.