### PR TITLE
Add a profile to bypass the duplicate module-info.java check in VS Code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,34 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- Only active in VS Code Java environment, used to bypass duplicate
+    module-info.java check in VS Code. It has no influence on the Maven build itself. -->
+            <id>m2e</id>
+            <activation>
+                <property>
+                    <name>m2e.version</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven.compiler-plugin.version}</version>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--module-version=${project.version}</arg>
+                                <arg>-Xlint:unchecked</arg>
+                            </compilerArgs>
+                            <testExcludes>
+                                <testExclude>**/module-info.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Currently opening this project in VS Code will report the error **"Build path contains duplicate entry 'module-info.java' for project x"**,  this is because VS Code Java tooling only allows a Java project to have at most one JPMS module-info.java. 

To workaround it, we can exclude test module-info.java when running in VS Code and fallback to the classpath way to handle test files. Since `m2e.version` property is only effective with VS Code Java tooling, it has no influence in Maven build itself.