### PR TITLE
Used canonical order for elements in module-info.java

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -26,6 +26,7 @@
  * @uses com.microsoft.gctoolkit.aggregator.Aggregator
  */
 module com.microsoft.gctoolkit.api {
+    requires java.logging;
 
     exports com.microsoft.gctoolkit;
     exports com.microsoft.gctoolkit.aggregator;
@@ -39,8 +40,7 @@ module com.microsoft.gctoolkit.api {
     exports com.microsoft.gctoolkit.jvm;
     exports com.microsoft.gctoolkit.time;
     exports com.microsoft.gctoolkit.util.concurrent;
-    requires java.logging;
 
-    uses com.microsoft.gctoolkit.jvm.JavaVirtualMachine;
     uses com.microsoft.gctoolkit.aggregator.Aggregation;
+    uses com.microsoft.gctoolkit.jvm.JavaVirtualMachine;
 }

--- a/parser/src/main/java/module-info.java
+++ b/parser/src/main/java/module-info.java
@@ -5,7 +5,13 @@
  * Contains the GCToolKit GC log parser. The parser is an internal module.
  */
 module com.microsoft.gctoolkit.parser {
+    requires com.microsoft.gctoolkit.api;
+    requires java.logging;
+
     exports com.microsoft.gctoolkit.parser to
+            com.microsoft.gctoolkit.vertx;
+
+    exports com.microsoft.gctoolkit.parser.datatype to
             com.microsoft.gctoolkit.vertx;
 
     exports com.microsoft.gctoolkit.parser.io to
@@ -19,10 +25,4 @@ module com.microsoft.gctoolkit.parser {
 
     exports com.microsoft.gctoolkit.parser.vmops to
             com.microsoft.gctoolkit.vertx;
-
-    exports com.microsoft.gctoolkit.parser.datatype to
-            com.microsoft.gctoolkit.vertx;
-
-    requires com.microsoft.gctoolkit.api;
-    requires java.logging;
 }

--- a/sample/src/main/java/module-info.java
+++ b/sample/src/main/java/module-info.java
@@ -10,10 +10,11 @@ module com.microsoft.gctoolkit.sample {
     requires com.microsoft.gctoolkit.vertx;
     requires java.logging;
 
-    exports com.microsoft.gctoolkit.sample.aggregation to com.microsoft.gctoolkit.vertx;
-
     exports com.microsoft.gctoolkit.sample;
 
-    provides com.microsoft.gctoolkit.aggregator.Aggregation
-            with com.microsoft.gctoolkit.sample.aggregation.HeapOccupancyAfterCollectionSummary;
+    exports com.microsoft.gctoolkit.sample.aggregation to
+            com.microsoft.gctoolkit.vertx;
+
+    provides com.microsoft.gctoolkit.aggregator.Aggregation with
+            com.microsoft.gctoolkit.sample.aggregation.HeapOccupancyAfterCollectionSummary;
 }

--- a/vertx/src/main/java/module-info.java
+++ b/vertx/src/main/java/module-info.java
@@ -6,14 +6,15 @@
  * @provides com.microsoft.gctoolkit.jvm.JavaVirtualMachine
  */
 module com.microsoft.gctoolkit.vertx {
+    requires com.microsoft.gctoolkit.api;
+    requires com.microsoft.gctoolkit.parser;
+    requires io.vertx.core;
+    requires java.logging;
+
     exports com.microsoft.gctoolkit.vertx.jvm to
             com.microsoft.gctoolkit.api;
 
-    provides com.microsoft.gctoolkit.jvm.JavaVirtualMachine
-            with com.microsoft.gctoolkit.vertx.jvm.DefaultJavaVirtualMachine;
+    provides com.microsoft.gctoolkit.jvm.JavaVirtualMachine with
+            com.microsoft.gctoolkit.vertx.jvm.DefaultJavaVirtualMachine;
 
-    requires com.microsoft.gctoolkit.api;
-    requires com.microsoft.gctoolkit.parser;
-    requires java.logging;
-    requires io.vertx.core;
 }


### PR DESCRIPTION
Sorry for all these pull requests. I'm also figuring this JPMS stuff out as we go along. It seems that the canonical order of the elements inside the module-info.java file in the OpenJDK/src is always the same:

`module some.module.name {
  requires ...
  
  requires transitive ...

  exports ... 

  exports ... to
    ...

  opens ... to 
    ...

  uses ...

  provides ... with 
    ...
}`

The order in our module-info.java files were a bit muddled, with requires sometimes appearing near the end.

Furthermore, the entries are usually alphabetically sorted.

(There is one case in the OpenJDK where requires transitive is out of order, but that was because someone changed it and didn't reorder it. I've sent a pull-request there too, but it's so insignificant I almost doubt it will be accepted.)