### PR TITLE
Hide starting gun

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -39,7 +39,6 @@ module com.microsoft.gctoolkit.api {
     exports com.microsoft.gctoolkit.io;
     exports com.microsoft.gctoolkit.jvm;
     exports com.microsoft.gctoolkit.time;
-    exports com.microsoft.gctoolkit.util.concurrent;
 
     uses com.microsoft.gctoolkit.aggregator.Aggregation;
     uses com.microsoft.gctoolkit.jvm.JavaVirtualMachine;

--- a/vertx/src/main/java/com/microsoft/gctoolkit/vertx/JVMEventSource.java
+++ b/vertx/src/main/java/com/microsoft/gctoolkit/vertx/JVMEventSource.java
@@ -4,7 +4,7 @@ package com.microsoft.gctoolkit.vertx;
 
 import com.microsoft.gctoolkit.io.DataSource;
 import com.microsoft.gctoolkit.parser.io.SafepointLogFile;
-import com.microsoft.gctoolkit.util.concurrent.StartingGun;
+import com.microsoft.gctoolkit.vertx.internal.util.concurrent.StartingGun;
 import io.vertx.core.AbstractVerticle;
 
 import java.io.IOException;

--- a/vertx/src/main/java/com/microsoft/gctoolkit/vertx/aggregator/AggregatorVerticle.java
+++ b/vertx/src/main/java/com/microsoft/gctoolkit/vertx/aggregator/AggregatorVerticle.java
@@ -6,7 +6,7 @@ import com.microsoft.gctoolkit.aggregator.Aggregation;
 import com.microsoft.gctoolkit.aggregator.Aggregator;
 import com.microsoft.gctoolkit.event.jvm.JVMEvent;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
-import com.microsoft.gctoolkit.util.concurrent.StartingGun;
+import com.microsoft.gctoolkit.vertx.internal.util.concurrent.StartingGun;
 import io.vertx.core.AbstractVerticle;
 
 import java.util.HashSet;

--- a/vertx/src/main/java/com/microsoft/gctoolkit/vertx/internal/util/concurrent/StartingGun.java
+++ b/vertx/src/main/java/com/microsoft/gctoolkit/vertx/internal/util/concurrent/StartingGun.java
@@ -1,4 +1,4 @@
-package com.microsoft.gctoolkit.util.concurrent;
+package com.microsoft.gctoolkit.vertx.internal.util.concurrent;
 
 import java.util.concurrent.locks.AbstractQueuedSynchronizer;
 

--- a/vertx/src/main/java/com/microsoft/gctoolkit/vertx/jvm/LogFileParser.java
+++ b/vertx/src/main/java/com/microsoft/gctoolkit/vertx/jvm/LogFileParser.java
@@ -3,7 +3,7 @@
 package com.microsoft.gctoolkit.vertx.jvm;
 
 import com.microsoft.gctoolkit.event.jvm.JVMEvent;
-import com.microsoft.gctoolkit.util.concurrent.StartingGun;
+import com.microsoft.gctoolkit.vertx.internal.util.concurrent.StartingGun;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.eventbus.DeliveryOptions;
 import com.microsoft.gctoolkit.parser.GCLogParser;

--- a/vertx/src/test/java/com/microsoft/gctoolkit/vertx/internal/util/concurrent/StartingGunTest.java
+++ b/vertx/src/test/java/com/microsoft/gctoolkit/vertx/internal/util/concurrent/StartingGunTest.java
@@ -1,4 +1,4 @@
-package com.microsoft.gctoolkit.util.concurrent;
+package com.microsoft.gctoolkit.vertx.internal.util.concurrent;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
After our reorganization, it seems that the StartingGun class is only needed inside the vertx module. I thus propose that we move it into an internal package inside our vertx module. No point having to maintain this if someone outside of our project starts using it.