### PR TITLE
Made test methods public to avoid --add-opens

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -16,20 +16,6 @@
     <description>Model APIs for aggregator, events, inputs.</description>
     <url>${project.parent.url}</url>
 
-    <build>
-        <plugins>
-            <plugin>
-               <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>
-                        --add-opens com.microsoft.gctoolkit.api/com.microsoft.gctoolkit.time=ALL-UNNAMED
-                        --add-opens com.microsoft.gctoolkit.api/com.microsoft.gctoolkit.io=ALL-UNNAMED
-                    </argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/api/src/test/java/com/microsoft/gctoolkit/io/RotatingGarbageCollectionLogFileTest.java
+++ b/api/src/test/java/com/microsoft/gctoolkit/io/RotatingGarbageCollectionLogFileTest.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-class RotatingGarbageCollectionLogFileTest {
+public class RotatingGarbageCollectionLogFileTest {
 
     private String[][] expected = new String[][] {
             new String[] {
@@ -52,7 +52,7 @@ class RotatingGarbageCollectionLogFileTest {
     };
 
     @Test
-    void getOrderedGarbageCollectionLogFiles() {
+    public void getOrderedGarbageCollectionLogFiles() {
         for(String[] data : expected) {
             try {
                 RotatingGCLogFile garbageCollectionLogFile = createRotatingGarbageCollectionLogFile(data[0]);
@@ -68,7 +68,7 @@ class RotatingGarbageCollectionLogFileTest {
     }
 
     @Test
-    void testRollingLogOrderUsage() {
+    public void testRollingLogOrderUsage() {
         Path path = getPath( "rolling/jdk14/rollinglogs/rollover.log");
         List<String> expected = Arrays.asList(
                 "rollover.log.3", "rollover.log.4", "rollover.log.0", "rollover.log.1", "rollover.log.2", "rollover.log"

--- a/api/src/test/java/com/microsoft/gctoolkit/time/DateTimeStampTest.java
+++ b/api/src/test/java/com/microsoft/gctoolkit/time/DateTimeStampTest.java
@@ -9,13 +9,13 @@ import java.time.format.DateTimeFormatter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class DateTimeStampTest {
+public class DateTimeStampTest {
 
     // For some reason, ISO_DATE_TIME doesn't like that time-zone is -0100. It wants -01:00.
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
     @Test
-    void getTimeStamp() {
+    public void getTimeStamp() {
         DateTimeStamp dateTimeStamp = new DateTimeStamp(.586);
         assertEquals(.586, dateTimeStamp.getTimeStamp(), 0.0001);
 
@@ -28,7 +28,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void getDateStampAsString() {
+    public void getDateStampAsString() {
         DateTimeStamp dateTimeStamp = new DateTimeStamp(.586);
         assertEquals("@0.586", dateTimeStamp.toString());
 
@@ -40,7 +40,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void getDateTime() {
+    public void getDateTime() {
         DateTimeStamp dateTimeStamp = new DateTimeStamp(.586);
         assertNull(dateTimeStamp.getDateTime());
 
@@ -52,7 +52,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void hasDateStamp() {
+    public void hasDateStamp() {
         DateTimeStamp dateTimeStamp = new DateTimeStamp(.586);
         assertFalse(dateTimeStamp.hasDateStamp());
 
@@ -64,7 +64,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void testHash() {
+    public void testHash() {
         DateTimeStamp a = new DateTimeStamp(.586);
         DateTimeStamp b = new DateTimeStamp(.587);
         assertNotEquals(a.hashCode(), b.hashCode());
@@ -100,7 +100,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void testEquals() {
+    public void testEquals() {
         DateTimeStamp a = new DateTimeStamp(.586);
         DateTimeStamp b = new DateTimeStamp(.587);
         assertNotEquals(a, b);
@@ -135,7 +135,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void testBefore() {
+    public void testBefore() {
         DateTimeStamp a = new DateTimeStamp(.586);
         DateTimeStamp b = new DateTimeStamp(.587);
         assertTrue(a.before(b));
@@ -183,7 +183,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void testAfter() {
+    public void testAfter() {
         DateTimeStamp a = new DateTimeStamp(.586);
         DateTimeStamp b = new DateTimeStamp(.587);
         assertTrue(b.after(a));
@@ -231,7 +231,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void compare() {
+    public void compare() {
         DateTimeStamp a = new DateTimeStamp("2018-04-04T09:10:00.586-0100");
         DateTimeStamp b = new DateTimeStamp("2018-04-04T09:10:00.587-0100");
         assertTrue(a.compare(b.getDateTime()) < 0);
@@ -252,7 +252,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void add() {
+    public void add() {
         DateTimeStamp a = new DateTimeStamp(.586);
         double a_ts = a.getTimeStamp();
         ZonedDateTime a_dt = a.getDateTime();
@@ -282,7 +282,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void minus() {
+    public void minus() {
         DateTimeStamp a = new DateTimeStamp(.586);
         double a_ts = a.getTimeStamp();
         ZonedDateTime a_dt = a.getDateTime();
@@ -312,7 +312,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void testMinus() {
+    public void testMinus() {
         DateTimeStamp a = new DateTimeStamp(.586);
         DateTimeStamp b = new DateTimeStamp(.587);
         double diff = a.minus(b);
@@ -332,7 +332,7 @@ class DateTimeStampTest {
     }
 
     @Test
-    void timeSpanInMinutes() {
+    public void timeSpanInMinutes() {
         DateTimeStamp a = new DateTimeStamp(.586);
         DateTimeStamp b = new DateTimeStamp(.587);
         double diff = a.timeSpanInMinutes(b);
@@ -350,152 +350,150 @@ class DateTimeStampTest {
     }
 
     @Test
-    void testCompareLessThan() {
+    public void testCompareLessThan() {
         DateTimeStamp smaller = new DateTimeStamp("2018-04-04T09:10:00.586-0100");
         DateTimeStamp greater = new DateTimeStamp("2018-04-04T10:10:00.587-0100");
         assertEquals(-1, smaller.compareTo(greater));
     }
 
     @Test
-    void testCompareGreaterThan() {
+    public void testCompareGreaterThan() {
         DateTimeStamp smaller = new DateTimeStamp("2018-04-04T09:10:00.586-0100");
         DateTimeStamp greater = new DateTimeStamp("2018-04-04T10:10:00.587-0100");
         assertEquals(1, greater.compareTo(smaller));
     }
 
     @Test
-    void testCompareEquals() {
+    public void testCompareEquals() {
         DateTimeStamp object1 = new DateTimeStamp("2018-04-04T10:10:00.586-0100");
         DateTimeStamp object2 = new DateTimeStamp("2018-04-04T10:10:00.586-0100");
         assertEquals(0, object1.compareTo(object2));
     }
 
     @Test
-    void testCompareEqualsTimeStamp() {
+    public void testCompareEqualsTimeStamp() {
         DateTimeStamp object1 = new DateTimeStamp("2018-04-04T10:10:00.586-0100", 123);
         DateTimeStamp object2 = new DateTimeStamp("2018-04-04T10:10:00.586-0100", 123);
         assertEquals(0, object2.compareTo(object1));
     }
 
     @Test
-    void testCompareGreaterTimeStamp() {
+    public void testCompareGreaterTimeStamp() {
         DateTimeStamp smaller = new DateTimeStamp("2018-04-04T10:10:00.586-0100", 122);
         DateTimeStamp greater = new DateTimeStamp("2018-04-04T10:10:00.586-0100", 123);
         assertEquals(1, greater.compareTo(smaller));
     }
 
     @Test
-    void testCompareSmallerTimeStamp() {
+    public void testCompareSmallerTimeStamp() {
         DateTimeStamp smaller = new DateTimeStamp("2018-04-04T10:10:00.586-0100", 123);
         DateTimeStamp greater = new DateTimeStamp("2018-04-04T10:10:00.586-0100", 124);
         assertEquals(-1, smaller.compareTo(greater));
     }
 
     @Test
-    void testCompareNullValue() {
+    public void testCompareNullValue() {
         DateTimeStamp smaller = new DateTimeStamp("2018-04-04T09:10:00.586-0100");
         assertEquals(-1, smaller.compareTo(null));
     }
 
     @Test
-    void testCompareEqualsTimeStampWithoutDateTime() {
+    public void testCompareEqualsTimeStampWithoutDateTime() {
         DateTimeStamp object1 = new DateTimeStamp(123);
         DateTimeStamp object2 = new DateTimeStamp(123);
         assertEquals(0, object2.compareTo(object1));
     }
 
     @Test
-    void testCompareGreaterTimeStampWithoutDateTime() {
+    public void testCompareGreaterTimeStampWithoutDateTime() {
         DateTimeStamp smaller = new DateTimeStamp(122);
         DateTimeStamp greater = new DateTimeStamp(124);
         assertEquals(1, greater.compareTo(smaller));
     }
 
     @Test
-    void testCompareSmallerTimeStampWithoutDateTime() {
+    public void testCompareSmallerTimeStampWithoutDateTime() {
         DateTimeStamp smaller = new DateTimeStamp(123);
         DateTimeStamp greater = new DateTimeStamp(124);
         assertEquals(-1, smaller.compareTo(greater));
     }
 
     @Test
-    void testCompareEqualsTimeStampMixed() {
+    public void testCompareEqualsTimeStampMixed() {
         DateTimeStamp object1 = new DateTimeStamp(1.522840200586E9);
         DateTimeStamp object2 = new DateTimeStamp("2018-04-04T10:10:00.586-0100");
         assertEquals(0, object2.compareTo(object1));
     }
 
     @Test
-    void testCompareGreaterTimeStampMixed() {
+    public void testCompareGreaterTimeStampMixed() {
         DateTimeStamp smaller = new DateTimeStamp(122);
         DateTimeStamp greater = new DateTimeStamp("2018-04-04T10:10:00.586-0100");
         assertEquals(1, greater.compareTo(smaller));
     }
 
     @Test
-    void testCompareSmallerTimeStampMixed() {
+    public void testCompareSmallerTimeStampMixed() {
         DateTimeStamp smaller = new DateTimeStamp(123);
         DateTimeStamp greater = new DateTimeStamp("2018-04-04T10:10:00.586-0100");
         assertEquals(-1, smaller.compareTo(greater));
     }
 
     @Test
-    void testNanWithZero() {
+    public void testNanWithZero() {
         DateTimeStamp dateTimeStamp = new DateTimeStamp(0.0);
         DateTimeStamp forComparing = new DateTimeStamp(0.0).add(Double.NaN);
         assertEquals(dateTimeStamp, forComparing);
     }
 
     @Test
-    void testNanWithNonZero() {
+    public void testNanWithNonZero() {
         DateTimeStamp dateTimeStamp = new DateTimeStamp("2018-04-04T10:10:00.586-0100");
         DateTimeStamp forComparing = new DateTimeStamp("2018-04-04T10:10:00.586-0100").add(Double.NaN);
         assertEquals(dateTimeStamp, forComparing);
     }
 
     @Test
-    void testNanWithMinusNonZero() {
+    public void testNanWithMinusNonZero() {
         DateTimeStamp dateTimeStamp = new DateTimeStamp("2018-04-04T10:10:00.586-0100");
         DateTimeStamp forComparing = new DateTimeStamp("2018-04-04T10:10:00.586-0100").minus(Double.NaN);
         assertEquals(dateTimeStamp, forComparing);
     }
 
     @Test
-    void testNanWithMinus() {
+    public void testNanWithMinus() {
         DateTimeStamp dateTimeStamp = new DateTimeStamp("2018-04-04T10:09:59.586-0100");
         DateTimeStamp forComparing = new DateTimeStamp("2018-04-04T10:10:00.586-0100").minus(1);
         assertEquals(dateTimeStamp, forComparing);
     }
 
     @Test
-    void testNanWithConstructor() {
+    public void testNanWithConstructor() {
         DateTimeStamp dateTimeStamp = new DateTimeStamp((String) null,Double.NaN);
         DateTimeStamp forComparing = new DateTimeStamp(0.0);
         assertEquals(dateTimeStamp, forComparing);
     }
 
     @Test
-    void testBeforeForNAN(){
+    public void testBeforeForNAN(){
         DateTimeStamp dateTimeStamp = new DateTimeStamp(-1);
         boolean before = dateTimeStamp.before(Double.NaN);
         assertTrue(before);
     }
 
     @Test
-    void testAfterForNAN(){
+    public void testAfterForNAN(){
         DateTimeStamp dateTimeStamp = new DateTimeStamp(1);
         boolean after = dateTimeStamp.after(Double.NaN);
         assertTrue(after);
     }
 
     @Test
-    void compareWithNANValue(){
+    public void compareWithNANValue(){
         DateTimeStamp dateTimeStamp = new DateTimeStamp(12d);
         DateTimeStamp dateTimeStampCompare = new DateTimeStamp(Double.NaN);
         int compare = dateTimeStamp.compareTo(dateTimeStampCompare);
         assertEquals(1,compare);
 
     }
-
-
 }

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -59,9 +59,6 @@
                             <value>${gcLogFile}</value>
                         </property>
                     </systemProperties>
-                    <argLine>
-                        --add-opens com.microsoft.gctoolkit.sample/com.microsoft.gctoolkit.sample.collections=ALL-UNNAMED
-                    </argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/sample/src/test/java/com/microsoft/gctoolkit/sample/collections/XYDataSetTest.java
+++ b/sample/src/test/java/com/microsoft/gctoolkit/sample/collections/XYDataSetTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class XYDataSetTest {
 
     @Test
-    void shouldScaleOnlyY_AxisDataSet() {
+    public void shouldScaleOnlyY_AxisDataSet() {
         var xyDataSet = new XYDataSet();
         xyDataSet.add(new Point(50, 100));
         XYDataSet scaledPoint = xyDataSet.scaleSeries(2);
@@ -21,7 +21,7 @@ public class XYDataSetTest {
     }
 
     @Test
-    void shouldReturnMaximumValueOfY_Axis() {
+    public void shouldReturnMaximumValueOfY_Axis() {
         var xyDataSet = new XYDataSet();
         xyDataSet.add(new Point(50, 100));
         xyDataSet.add(new Point(100, 140));
@@ -32,7 +32,7 @@ public class XYDataSetTest {
     }
 
     @Test
-    void shouldReturnScaledAndTranslatedX_AxisDataSet() {
+    public void shouldReturnScaledAndTranslatedX_AxisDataSet() {
         var xyDataSet = new XYDataSet();
         xyDataSet.add(new Point(50, 100));
         var translated = xyDataSet.scaleAndTranslateXAxis(2, 20);
@@ -41,7 +41,7 @@ public class XYDataSetTest {
     }
 
     @Test
-    void maxOnEmptyDataSet() {
+    public void maxOnEmptyDataSet() {
         assertTrue(new XYDataSet().maxOfY().isEmpty());
     }
 

--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -14,19 +14,6 @@
     <description>Messaging backplane for connecting GC log parsers and JVM event consumers.</description>
     <url>${project.parent.url}</url>
 
-    <build>
-        <plugins>
-            <plugin>
-               <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>
-                        --add-opens com.microsoft.gctoolkit.vertx/com.microsoft.gctoolkit.vertx.io=ALL-UNNAMED
-                    </argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>com.microsoft.gctoolkit</groupId>

--- a/vertx/src/test/java/com/microsoft/gctoolkit/vertx/io/GarbageCollectionEventSourceTest.java
+++ b/vertx/src/test/java/com/microsoft/gctoolkit/vertx/io/GarbageCollectionEventSourceTest.java
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class GarbageCollectionEventSourceTest {
+public class GarbageCollectionEventSourceTest {
 
     private static final Logger LOG = Logger.getLogger(GarbageCollectionEventSourceTest.class.getName());
 
@@ -34,7 +34,7 @@ class GarbageCollectionEventSourceTest {
     }
     
     @Test
-    void testRotatingLogDirectory() {
+    public void testRotatingLogDirectory() {
         Path path = new TestLogFile("rotating_directory").getFile().toPath();
         assertExpectedLineCountInLog(72210, loadLogFile(path, true));
     }
@@ -47,31 +47,31 @@ class GarbageCollectionEventSourceTest {
         }
     */
     @Test
-    void testGZipTarFileLineCount() {
+    public void testGZipTarFileLineCount() {
         Path path = new TestLogFile("streaming/gc.log.tar.gz").getFile().toPath();
         assertExpectedLineCountInLog(410056, loadLogFile(path, false));
     }
 
     @Test
-    void testSingleLogInZipLineCount() {
+    public void testSingleLogInZipLineCount() {
         Path path = new TestLogFile("streaming/gc.log.zip").getFile().toPath();
         assertExpectedLineCountInLog(431604, loadLogFile(path, false));
     }
 
     @Test
-    void testRotatingLogsLineCount() {
+    public void testRotatingLogsLineCount() {
         Path path = new TestLogFile("rotating.zip").getFile().toPath();
         assertExpectedLineCountInLog(72210, loadLogFile(path, true));
     }
 
     @Test
-    void testRotatingLogsRotatingLineCount() {
+    public void testRotatingLogsRotatingLineCount() {
         Path path = new TestLogFile("rotating.zip").getFile().toPath();
         assertExpectedLineCountInLog(72210, loadLogFile(path, true));
     }
 
     @Test
-    void testZippedDirectoryWithRotatingLogRotatingLineCount() {
+    public void testZippedDirectoryWithRotatingLogRotatingLineCount() {
         Path path = new TestLogFile("streaming/rotating_directory.zip").getFile().toPath();
         assertExpectedLineCountInLog(72211, loadLogFile(path, true));
     }
@@ -103,7 +103,7 @@ class GarbageCollectionEventSourceTest {
         assertEquals(expectedNumberOfLines, consumer.getEventCount());
     }
 
-    class GCLogConsumer extends AbstractVerticle {
+    private static class GCLogConsumer extends AbstractVerticle {
 
         private final CountDownLatch eof = new CountDownLatch(1);
         private int eventCount = 0;
@@ -134,7 +134,7 @@ class GarbageCollectionEventSourceTest {
     }
 
     @Test
-    void testEqualsForDifferentObject() {
+    public void testEqualsForDifferentObject() {
         GCEvent gcEvent = new DefNew(new DateTimeStamp("2018-04-04T09:10:00.586-0100"), GCCause.WARMUP,102);
         assertNotEquals(gcEvent, new ArrayList<>());
     }


### PR DESCRIPTION
The reason that we needed --add-opens for our tests was because our test classes and the test methods were not public. I have changed the test classes to be public and their test methods too, so that junit does not have an issue calling them and have removed the --add-opens from the dom.xml files. I think @karianna will be pleased as punch.