### PR TITLE
bump vert.x version to 4.1.5

### DIFF
--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>4.1.2</version>
+            <version>4.1.5</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
After changing version, confirmed that all io.netty dependencies are sitting at 4.1.68.Final

Will need to do a release after this merges so users of this lib can resolve security issues. 