### PR TITLE
StartingGunTest could sometimes cause the build to fail

### DIFF
--- a/vertx/src/test/java/com/microsoft/gctoolkit/vertx/internal/util/concurrent/StartingGunTest.java
+++ b/vertx/src/test/java/com/microsoft/gctoolkit/vertx/internal/util/concurrent/StartingGunTest.java
@@ -61,7 +61,7 @@ public class StartingGunTest {
     thread.start();
 
     sg.awaitUninterruptibly();
-    assertTrue(testingThread.isInterrupted());
+    assertTrue(Thread.interrupted());
     thread.join(); // wait for that thread to finish
   }
 


### PR DESCRIPTION
It seems that JUnit reads the method order from Class.getMethods or getDeclaredMethods. These methods are returned in an arbitrary order, in other words, not necessarily in the order in which the methods are declared inside the class. The order might also change between runs. One of the test methods, testInterruptedStatus() interrupted the testing thread. If that was the last method to test, then everything would be fine, but if it was not, it could cause the others to fail. Instead of isInterrupted(), we now use interrupted(), which resets the interrupted status.