### PR TITLE
Update README.md

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -8,10 +8,10 @@ We use the Maven wrapper (`mvnw`) so you don't have to change your system wide M
 
 ### From Maven
 
-Compile the sample with `mvnw compile`, then use `mvnw exec:exec` to run the sample.
+Install the sample to your local maven repository with `mvnw install`, then use `mvnw exec:exec` to run the sample.
 
 ```shell
-mvnw clean compile
+mvnw clean install
 mvnw exec:exec
 ```
 


### PR DESCRIPTION
To run the sample, `mvnw compile` is not enough; `mvn install` is needed so that the artifacts are created in the local maven repository and can be found by the next step. Then, one needs to first cd sample and then run `mvnw exec:exec` or `mvn exec:exec`.