### PR TITLE
fix: add UnifiedJavaVirtualMachine to modulo-info

### DIFF
--- a/vertx/src/main/java/module-info.java
+++ b/vertx/src/main/java/module-info.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import com.microsoft.gctoolkit.vertx.jvm.PreUnifiedJavaVirtualMachine;
+import com.microsoft.gctoolkit.vertx.jvm.UnifiedJavaVirtualMachine;
 
 /**
  * Contains a vertx based implementation of GCToolKit. The vertx implementation is an internal module.
@@ -17,6 +18,7 @@ module com.microsoft.gctoolkit.vertx {
             com.microsoft.gctoolkit.api;
 
     provides com.microsoft.gctoolkit.jvm.JavaVirtualMachine with
-            PreUnifiedJavaVirtualMachine;
+            PreUnifiedJavaVirtualMachine,
+            UnifiedJavaVirtualMachine;
 
 }

--- a/vertx/src/main/java/module-info.java
+++ b/vertx/src/main/java/module-info.java
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import com.microsoft.gctoolkit.vertx.jvm.PreUnifiedJavaVirtualMachine;
-import com.microsoft.gctoolkit.vertx.jvm.UnifiedJavaVirtualMachine;
-
 /**
  * Contains a vertx based implementation of GCToolKit. The vertx implementation is an internal module.
  * @provides com.microsoft.gctoolkit.jvm.JavaVirtualMachine
@@ -18,7 +15,7 @@ module com.microsoft.gctoolkit.vertx {
             com.microsoft.gctoolkit.api;
 
     provides com.microsoft.gctoolkit.jvm.JavaVirtualMachine with
-            PreUnifiedJavaVirtualMachine,
-            UnifiedJavaVirtualMachine;
+            com.microsoft.gctoolkit.vertx.jvm.PreUnifiedJavaVirtualMachine,
+            com.microsoft.gctoolkit.vertx.jvm.UnifiedJavaVirtualMachine;
 
 }


### PR DESCRIPTION
Hi,

Could I have a review of this fix?

UnifiedJavaVirtualMachine should be provided as a service in vertx module, otherwise UnifiedJavaVirtualMachine can not be loaded by GCToolKit::loadJavaVirtualMachine.

Thanks,
Yifeng