### PR TITLE
[ZGC][parser] Ensure that ZGCMemoryPoolSummary and OccupancySummary use kilobytes

### DIFF
--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
@@ -83,14 +83,14 @@ public class ZGCParserTest {
                 assertEquals(toInt(12.962d, 1000), toInt(zgc.getConcurrentRelocateDuration(), 1000));
 
                 //Memory
-                assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkStart(), 936L, 42L, 3160L, 894)); //1074L, 1074L, 1074L));
-                assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkEnd(), 1074L, 42L, 3084L, 970L));
-                assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateStart(),1074L, 42L, 3852L, 202L));
-                assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateEnd(), 1074L, 42L, 3868L, 186L));
+                assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkStart(), 958464, 43008, 3235840, 915456));
+                assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkEnd(), 1099776, 43008, 3158016, 993280));
+                assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateStart(),1099776, 43008, 3944448, 206848));
+                assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateEnd(), 1099776, 43008, 3960832, 190464));
 
-                assertTrue(checkOccupancySummary(zgc.getLive(), 8L, 8L, 8L));
-                assertTrue(checkOccupancySummary(zgc.getAllocated(), 172L, 172L, 376L));
-                assertTrue(checkOccupancySummary(zgc.getGarbage(), 885L, 117L, 5L));
+                assertTrue(checkOccupancySummary(zgc.getLive(), 8192, 8192, 8192));
+                assertTrue(checkOccupancySummary(zgc.getAllocated(), 176128, 176128, 385024));
+                assertTrue(checkOccupancySummary(zgc.getGarbage(), 906240, 119808, 5120));
 
                 assertTrue(checkReclaimSummary(zgc.getReclaimed(), 768L, 880L));
                 assertTrue(checkReclaimSummary(zgc.getMemorySummary(), 894L, 186L));


### PR DESCRIPTION
Ensure that ZGC memory values are normalized to kilobytes. The code in its current form will return a double without taking into account the units associated with the memory value. This can lead to multiple GC cycles that report odd results. This diff ensures that as they are parsed they are normalized to a long value in kilobytes. The regex's already capture the units so we'll simply scale the constructor inputs to ZGCMemoryPoolSummary and OccupancySummary by the captured unit string. We'll use the helper method `.toKBytes(...)` which is available to us in the the trace class already.

Please let me know if there is a project code formatting standard, I'd be happy to reformat to meet the project standards. While working, the editor cleaned up a number of spacing issues which lead to a slightly larger PR than expected. I wish this could have been picked up in a separate, format only diff. Anyways. Please let me know if I can better address this.