### PR TITLE
[ZGC] Improve parsing for Java 17 style output

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
@@ -30,6 +30,9 @@ public class ZGCCycle extends GCEvent {
     private DateTimeStamp concurrentMarkTimeStamp;
     private double concurrentMarkDuration;
 
+    private DateTimeStamp concurrentMarkFreeTimeStamp;
+    private double concurrentMarkFreeDuration;
+
     private DateTimeStamp pauseMarkEndTimeStamp;
     private double pauseMarkEndDuration;
 
@@ -47,7 +50,6 @@ public class ZGCCycle extends GCEvent {
 
     private DateTimeStamp concurrentRelocateTimeStamp;
     private double concurrentRelocateDuration;
-    private ZGCMemoryPoolSummary metaspace;
 
     private double[] load = new double[3];
     private double[] mmu = new double[6];
@@ -76,6 +78,19 @@ public class ZGCCycle extends GCEvent {
     public void setConcurrentMark(DateTimeStamp concurrentMarkTimeStamp, double duration) {
         this.concurrentMarkTimeStamp = concurrentMarkTimeStamp;
         this.concurrentMarkDuration = duration;
+    }
+
+    public DateTimeStamp getConcurrentMarkFreeTimeStamp() {
+        return concurrentMarkFreeTimeStamp;
+    }
+
+    public double getConcurrentMarkFreeDuration() {
+        return concurrentMarkFreeDuration;
+    }
+
+    public void setConcurrentMarkFree(DateTimeStamp concurrentMarkFreeStart, double duration) {
+        this.concurrentMarkFreeTimeStamp = concurrentMarkFreeStart;
+        this.concurrentMarkFreeDuration = duration;
     }
 
     public DateTimeStamp getPauseMarkEndTimeStamp() {
@@ -166,6 +181,7 @@ public class ZGCCycle extends GCEvent {
     private OccupancySummary garbage;
     private ReclaimSummary reclaimed;
     private ReclaimSummary memorySummary;
+    private ZGCMetaspaceSummary metaspace;
 
     public void setMarkStart(ZGCMemoryPoolSummary summary) {
         this.markStart = summary;
@@ -203,6 +219,10 @@ public class ZGCCycle extends GCEvent {
         this.memorySummary = summary;
     }
 
+    public void setMetaspace(ZGCMetaspaceSummary summary) {
+        this.metaspace = summary;
+    }
+
     public ZGCMemoryPoolSummary getMarkStart() {
         return markStart;
     }
@@ -237,6 +257,10 @@ public class ZGCCycle extends GCEvent {
 
     public ReclaimSummary getMemorySummary() {
         return memorySummary;
+    }
+
+    public ZGCMetaspaceSummary getMetaspace() {
+        return metaspace;
     }
 
     public void setLoadAverages(double[] load) {
@@ -277,13 +301,6 @@ public class ZGCCycle extends GCEvent {
                 return 0.0d;
         }
     }
-
-    public void setMetaspace(ZGCMemoryPoolSummary summary) {
-        this.metaspace = summary;
-    }
-    public ZGCMemoryPoolSummary getMetaspace() {
-        return metaspace;
-    }
 }
 
 // Concurrent Mark duration
@@ -302,37 +319,39 @@ public class ZGCCycle extends GCEvent {
 // Memory stats
 
 /*
-"[3.558s][info ][gc,start       ] GC(3) Garbage Collection (Warmup)",
-        "[3.559s][info ][gc,phases      ] GC(3) Pause Mark Start 0.460ms",
-        "[3.573s][info ][gc,phases      ] GC(3) Concurrent Mark 14.621ms",
-        "[3.574s][info ][gc,phases      ] GC(3) Pause Mark End 0.830ms",
-        "[3.578s][info ][gc,phases      ] GC(3) Concurrent Process Non-Strong References 3.654ms",
-        "[3.578s][info ][gc,phases      ] GC(3) Concurrent Reset Relocation Set 0.194ms",
-        "[3.582s][info ][gc,phases      ] GC(3) Concurrent Select Relocation Set 3.193ms",
-        "[3.583s][info ][gc,phases      ] GC(3) Pause Relocate Start 0.794ms",
-        "[3.596s][info ][gc,phases      ] GC(3) Concurrent Relocate 12.962ms",
-        "[3.596s][info ][gc,load        ] GC(3) Load: 4.28/3.95/3.22",
-        "[3.596s][info ][gc,mmu         ] GC(3) MMU: 2ms/32.7%, 5ms/60.8%, 10ms/80.4%, 20ms/85.4%, 50ms/90.8%, 100ms/95.4%",
-        "[3.596s][info ][gc,marking     ] GC(3) Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 1 completion(s), 0 continuation(s)",
-        "[3.596s][info ][gc,reloc       ] GC(3) Relocation: Successful, 6M relocated",
-        "[3.596s][info ][gc,nmethod     ] GC(3) NMethods: 1163 registered, 0 unregistered",
-        "[3.596s][info ][gc,metaspace   ] GC(3) Metaspace: 14M used, 15M capacity, 15M committed, 16M reserved",
-        "[3.596s][info ][gc,ref         ] GC(3) Soft: 391 encountered, 0 discovered, 0 enqueued",
-        "[3.596s][info ][gc,ref         ] GC(3) Weak: 587 encountered, 466 discovered, 0 enqueued",
-        "[3.596s][info ][gc,ref         ] GC(3) Final: 799 encountered, 0 discovered, 0 enqueued",
-        "[3.596s][info ][gc,ref         ] GC(3) Phantom: 33 encountered, 1 discovered, 0 enqueued",
-        "[3.596s][info ][gc,heap        ] GC(3) Min Capacity: 8M(0%)",
-        "[3.596s][info ][gc,heap        ] GC(3) Max Capacity: 4096M(100%)",
-        "[3.596s][info ][gc,heap        ] GC(3) Soft Max Capacity: 4096M(100%)",
-        "[3.596s][info ][gc,heap        ] GC(3)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low",
-        "[3.596s][info ][gc,heap        ] GC(3)  Capacity:      936M (23%)        1074M (26%)        1074M (26%)        1074M (26%)        1074M (26%)         936M (23%)",
-        "[3.596s][info ][gc,heap        ] GC(3)   Reserve:       42M (1%)           42M (1%)           42M (1%)           42M (1%)           42M (1%)           42M (1%)",
-        "[3.596s][info ][gc,heap        ] GC(3)      Free:     3160M (77%)        3084M (75%)        3852M (94%)        3868M (94%)        3930M (96%)        3022M (74%)",
-        "[3.596s][info ][gc,heap        ] GC(3)      Used:      894M (22%)         970M (24%)         202M (5%)          186M (5%)         1032M (25%)         124M (3%)",
-        "[3.596s][info ][gc,heap        ] GC(3)      Live:         -                 8M (0%)            8M (0%)            8M (0%)             -                  -",
-        "[3.596s][info ][gc,heap        ] GC(3) Allocated:         -               172M (4%)          172M (4%)          376M (9%)             -                  -",
-        "[3.596s][info ][gc,heap        ] GC(3)   Garbage:         -               885M (22%)         117M (3%)            5M (0%)             -                  -",
-        "[3.596s][info ][gc,heap        ] GC(3) Reclaimed:         -                  -               768M (19%)         880M (21%)            -                  -",
-        "[3.596s][info ][gc             ] GC(3) Garbage Collection (Warmup) 894M(22%)->186M(5%)"
-
- */
+[32.121s][info][gc,start    ] GC(2) Garbage Collection (Metadata GC Threshold)
+[32.121s][info][gc,phases   ] GC(2) Pause Mark Start 0.023ms
+[32.166s][info][gc,phases   ] GC(2) Concurrent Mark 44.623ms
+[32.166s][info][gc,phases   ] GC(2) Pause Mark End 0.029ms
+[32.166s][info][gc,phases   ] GC(2) Concurrent Mark Free 0.001ms
+[32.172s][info][gc,phases   ] GC(2) Concurrent Process Non-Strong References 5.797ms
+[32.172s][info][gc,phases   ] GC(2) Concurrent Reset Relocation Set 0.012ms
+[32.178s][info][gc,phases   ] GC(2) Concurrent Select Relocation Set 6.446ms
+[32.179s][info][gc,phases   ] GC(2) Pause Relocate Start 0.024ms
+[32.193s][info][gc,phases   ] GC(2) Concurrent Relocate 14.013ms
+[32.193s][info][gc,load     ] GC(2) Load: 7.28/6.63/5.01
+[32.193s][info][gc,mmu      ] GC(2) MMU: 2ms/98.2%, 5ms/99.3%, 10ms/99.5%, 20ms/99.7%, 50ms/99.9%, 100ms/99.9%
+[32.193s][info][gc,marking  ] GC(2) Mark: 4 stripe(s), 3 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s)
+[32.193s][info][gc,marking  ] GC(2) Mark Stack Usage: 32M
+[32.193s][info][gc,metaspace] GC(2) Metaspace: 60M used, 60M committed, 1080M reserved
+[32.193s][info][gc,ref      ] GC(2) Soft: 5447 encountered, 0 discovered, 0 enqueued
+[32.193s][info][gc,ref      ] GC(2) Weak: 5347 encountered, 2016 discovered, 810 enqueued
+[32.193s][info][gc,ref      ] GC(2) Final: 1041 encountered, 113 discovered, 105 enqueued
+[32.193s][info][gc,ref      ] GC(2) Phantom: 558 encountered, 501 discovered, 364 enqueued
+[32.193s][info][gc,reloc    ] GC(2) Small Pages: 235 / 470M, Empty: 32M, Relocated: 40M, In-Place: 0
+[32.193s][info][gc,reloc    ] GC(2) Medium Pages: 2 / 64M, Empty: 0M, Relocated: 3M, In-Place: 0
+[32.193s][info][gc,reloc    ] GC(2) Large Pages: 3 / 24M, Empty: 8M, Relocated: 0M, In-Place: 0
+[32.193s][info][gc,reloc    ] GC(2) Forwarding Usage: 13M
+[32.193s][info][gc,heap     ] GC(2) Min Capacity: 8M(0%)
+[32.193s][info][gc,heap     ] GC(2) Max Capacity: 28686M(100%)
+[32.193s][info][gc,heap     ] GC(2) Soft Max Capacity: 28686M(100%)
+[32.193s][info][gc,heap     ] GC(2)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low
+[32.193s][info][gc,heap     ] GC(2)  Capacity:     1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)
+[32.193s][info][gc,heap     ] GC(2)      Free:    28128M (98%)       28110M (98%)       28148M (98%)       28560M (100%)      28560M (100%)      28108M (98%)
+[32.193s][info][gc,heap     ] GC(2)      Used:      558M (2%)          576M (2%)          538M (2%)          126M (0%)          578M (2%)          126M (0%)
+[32.193s][info][gc,heap     ] GC(2)      Live:         -                71M (0%)           71M (0%)           71M (0%)             -                  -
+[32.193s][info][gc,heap     ] GC(2) Allocated:         -                18M (0%)           20M (0%)           18M (0%)             -                  -
+[32.193s][info][gc,heap     ] GC(2)   Garbage:         -               486M (2%)          446M (2%)           35M (0%)             -                  -
+[32.193s][info][gc,heap     ] GC(2) Reclaimed:         -                  -                40M (0%)          450M (2%)             -                  -
+[32.193s][info][gc          ] GC(2) Garbage Collection (Metadata GC Threshold) 558M(2%)->126M(0%)
+*/

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMemoryPoolSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMemoryPoolSummary.java
@@ -6,23 +6,17 @@ public class ZGCMemoryPoolSummary {
 
     // these are effectively final but David likes to see an explicit final. In Java 14 this could be a Record.
     private final long capacity;
-    private final long reserved;
     private final long free;
     private final long used;
 
-    public ZGCMemoryPoolSummary(long capacity, long reserved, long free, long used) {
+    public ZGCMemoryPoolSummary(long capacity, long free, long used) {
         this.capacity = capacity;
-        this.reserved = reserved;
         this.free = free;
         this.used = used;
     }
 
     public long getCapacity() {
         return this.capacity;
-    }
-
-    public long getReserved() {
-        return this.reserved;
     }
 
     public long getFree() {

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMetaspaceSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMetaspaceSummary.java
@@ -1,0 +1,25 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCMetaspaceSummary {
+    private final long used;
+    private final long committed;
+    private final long reserved;
+
+    public ZGCMetaspaceSummary(long used, long committed, long reserved) {
+        this.used = used;
+        this.committed = committed;
+        this.reserved = reserved;
+    }
+
+    public long getUsed() {
+        return used;
+    }
+
+    public long getCommitted() {
+        return committed;
+    }
+
+    public long getReserved() {
+        return reserved;
+    }
+}

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
@@ -24,7 +24,7 @@ public interface ZGCPatterns extends UnifiedPatterns {
     //[3.578s][info ][gc,phases      ] GC(3) Concurrent Reset Relocation Set 0.194ms
     //[3.582s][info ][gc,phases      ] GC(3) Concurrent Select Relocation Set 3.193ms
     //[3.596s][info ][gc,phases      ] GC(3) Concurrent Relocate 12.962ms
-    GCParseRule CONCURRENT_PHASE = new GCParseRule("Concurrent Phase","Concurrent (Mark|Process Non-Strong References|Reset Relocation Set|Select Relocation Set|Relocate) " + GenericTokens.PAUSE_TIME);
+    GCParseRule CONCURRENT_PHASE = new GCParseRule("Concurrent Phase","Concurrent (Mark|Mark Free|Process Non-Strong References|Reset Relocation Set|Select Relocation Set|Relocate) " + GenericTokens.PAUSE_TIME);
 
     //[3.596s][info ][gc,load        ] GC(3) Load: 4.28/3.95/3.22
     GCParseRule LOAD = new GCParseRule("Load","Load: " + GenericTokens.REAL_VALUE + "/" + GenericTokens.REAL_VALUE + "/" + GenericTokens.REAL_VALUE);
@@ -41,8 +41,8 @@ public interface ZGCPatterns extends UnifiedPatterns {
     //[3.596s][info ][gc,nmethod     ] GC(3) NMethods: 1163 registered, 0 unregistered
     GCParseRule NMETHODS = new GCParseRule("NMethods"," NMethods: " + GenericTokens.INT + " registered, " + GenericTokens.INT + " unregistered");
 
-    //[3.596s][info ][gc,metaspace   ] GC(3) Metaspace: 14M used, 15M capacity, 15M committed, 16M reserved
-    GCParseRule METASPACE = new GCParseRule( "Metaspace", "Metaspace: " + GenericTokens.INT + GenericTokens.UNITS + " used, " + GenericTokens.INT + GenericTokens.UNITS + " capacity, " + GenericTokens.INT + GenericTokens.UNITS + " committed, " + GenericTokens.INT + GenericTokens.UNITS + " reserved");
+    //[3.596s][info ][info ][gc,metaspace   ] GC(3) Metaspace: 84M used, 85M committed, 1104M reserved
+    GCParseRule METASPACE = new GCParseRule( "Metaspace", "Metaspace: " + GenericTokens.INT + GenericTokens.UNITS + " used, " + GenericTokens.INT + GenericTokens.UNITS + " committed, " + GenericTokens.INT + GenericTokens.UNITS + " reserved");
 
     //[3.596s][info ][gc,ref         ] GC(3) Soft: 391 encountered, 0 discovered, 0 enqueued
     //[3.596s][info ][gc,ref         ] GC(3) Weak: 587 encountered, 466 discovered, 0 enqueued
@@ -55,17 +55,16 @@ public interface ZGCPatterns extends UnifiedPatterns {
     //[3.596s][info ][gc,heap        ] GC(3) Soft Max Capacity: 4096M(100%)
     GCParseRule CAPACITY = new GCParseRule("Capacity", "(Min Capacity|Max Capacity|Soft Max Capacity): " + MEMORY_PERCENT);
 
-    //                "[3.596s][info ][gc,heap        ] GC(3)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low",
+    //[3.596s][info ][gc,heap        ] GC(3)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low
     GCParseRule MEMORY_TABLE_HEADER = new GCParseRule("Memory Table Header", "Mark Start\\s+Mark End\\s+Relocate Start");
 
-    //[3.596s][info ][gc,heap        ] GC(3)  Capacity:      936M (23%)        1074M (26%)        1074M (26%)        1074M (26%)        1074M (26%)         936M (23%)",
-    //[3.596s][info ][gc,heap        ] GC(3)   Reserve:       42M (1%)           42M (1%)           42M (1%)           42M (1%)           42M (1%)           42M (1%)",
-    //[3.596s][info ][gc,heap        ] GC(3)      Free:     3160M (77%)        3084M (75%)        3852M (94%)        3868M (94%)        3930M (96%)        3022M (74%)",
-    //[3.596s][info ][gc,heap        ] GC(3)      Used:      894M (22%)         970M (24%)         202M (5%)          186M (5%)         1032M (25%)         124M (3%)",
+    //[3.596s][info ][gc,heap        ] GC(3)  Capacity:    36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)
+    //[3.596s][info ][gc,heap        ] GC(3)      Free:    30614M (83%)       30460M (83%)       30988M (84%)       35938M (97%)       35938M (97%)       30458M (83%)
+    //[3.596s][info ][gc,heap        ] GC(3)      Used:     6250M (17%)        6404M (17%)        5876M (16%)         926M (3%)         6406M (17%)         926M (3%)
     //************
     //This rule is scary in that it captures CAPACITY IF the spaces are removed from before 'Capacity' in the capture group below.
     //****** WARNING DO NOT REMOVE SPACES FROM THE RULE ******* THINGS WILL BREAK!!!! *************
-    GCParseRule MEMORY_TABLE_ENTRY_SIZE = new GCParseRule("Memory table entry size", "\\s*(Capacity|Reserve|Free|Used):\\s+" + MEMORY_PERCENT + "\\s*" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT);
+    GCParseRule MEMORY_TABLE_ENTRY_SIZE = new GCParseRule("Memory table entry size", "\\s*(Capacity||Free|Used):\\s+" + MEMORY_PERCENT + "\\s*" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT);
 
     //[3.596s][info ][gc,heap        ] GC(3)      Live:         -                 8M (0%)            8M (0%)            8M (0%)             -                  -
     //[3.596s][info ][gc,heap        ] GC(3) Allocated:         -               172M (4%)          172M (4%)          376M (9%)             -                  -

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ShenandoahParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ShenandoahParserTest.java
@@ -130,8 +130,8 @@ public class ShenandoahParserTest {
 
     }
 
-    private boolean checkZGCMemoryPoolSummary(ZGCMemoryPoolSummary summary, long capacity, long reserved, long free, long used) {
-        return summary.getCapacity() == capacity && summary.getReserved() == reserved && summary.getFree() == free && summary.getUsed() == used;
+    private boolean checkZGCMemoryPoolSummary(ZGCMemoryPoolSummary summary, long capacity, long free, long used) {
+        return summary.getCapacity() == capacity && summary.getFree() == free && summary.getUsed() == used;
     }
 
     private boolean checkOccupancySummary(OccupancySummary summary, long markEnd, long relocateStart, long relocateEnd) {

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserRulesTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserRulesTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.logging.Logger;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ZGCParserRulesTest implements ZGCPatterns {
 
@@ -75,85 +77,81 @@ public class ZGCParserRulesTest implements ZGCPatterns {
             LOAD,
             MMU,
             MARK_SUMMARY,                  //  5
-            RELOCATION_SUMMARY,
             NMETHODS,
             METASPACE,
             REFERENCE_PROCESSING,
-            CAPACITY,                      // 10
-            MEMORY_TABLE_HEADER,
+            CAPACITY,
+            MEMORY_TABLE_HEADER,            // 10
             MEMORY_TABLE_ENTRY_SIZE,
             MEMORY_TABLE_ENTRY_OCCUPANCY,
             MEMORY_TABLE_ENTRY_RECLAIMED,
             MEMORY_SUMMARY
     };
 
-    private String[][] lines = {
+   private String[][] lines = {
+           { // 0
+                   "[32.121s][info][gc,start    ] GC(2) Garbage Collection (Metadata GC Threshold)",
+           },
+           { // 1
+                   "[32.121s][info][gc,phases   ] GC(2) Pause Mark Start 0.023ms",
+                   "[32.179s][info][gc,phases   ] GC(2) Pause Relocate Start 0.024ms",
+                   "[32.166s][info][gc,phases   ] GC(2) Pause Mark End 0.029ms",
+           },
+           { // 2
+                   "[32.166s][info][gc,phases   ] GC(2) Concurrent Mark 44.623ms",
+                   "[32.166s][info][gc,phases   ] GC(2) Concurrent Mark Free 0.001ms",
+                   "[32.172s][info][gc,phases   ] GC(2) Concurrent Process Non-Strong References 5.797ms",
+                   "[32.172s][info][gc,phases   ] GC(2) Concurrent Reset Relocation Set 0.012ms",
+                   "[32.178s][info][gc,phases   ] GC(2) Concurrent Select Relocation Set 6.446ms",
+                   "[32.193s][info][gc,phases   ] GC(2) Concurrent Relocate 14.013ms",
+           },
+           { // 3
+                   "[32.193s][info][gc,load     ] GC(2) Load: 7.28/6.63/5.01",
+           },
+           { // 4
+                   "[32.193s][info][gc,mmu      ] GC(2) MMU: 2ms/98.2%, 5ms/99.3%, 10ms/99.5%, 20ms/99.7%, 50ms/99.9%, 100ms/99.9%",
+           },
+           { // 5
+                   "[32.193s][info][gc,marking  ] GC(2) Mark: 4 stripe(s), 3 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s) ",
+           },
+           { // 6
+                   "[32.193s][info ][gc,nmethod ] GC(2) NMethods: 1163 registered, 0 unregistered"
+           },
+           { // 7
+                   "[32.193s][info][gc,metaspace] GC(2) Metaspace: 60M used, 60M committed, 1080M reserved",
+           },
+           { // 8
+                   "[32.193s][info][gc,ref      ] GC(2) Soft: 5447 encountered, 0 discovered, 0 enqueued",
+                   "[32.193s][info][gc,ref      ] GC(2) Weak: 5347 encountered, 2016 discovered, 810 enqueued",
+                   "[32.193s][info][gc,ref      ] GC(2) Final: 1041 encountered, 113 discovered, 105 enqueued",
+                   "[32.193s][info][gc,ref      ] GC(2) Phantom: 558 encountered, 501 discovered, 364 enqueued",
+           },
+           { // 9
+                   "[32.193s][info][gc,heap     ] GC(2) Min Capacity: 8M(0%)",
+                   "[32.193s][info][gc,heap     ] GC(2) Max Capacity: 28686M(100%)",
+                   "[32.193s][info][gc,heap     ] GC(2) Soft Max Capacity: 28686M(100%)",
+           },
+           { // 10
+                    "[32.193s][info][gc,heap     ] GC(2)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low         ",
+           },
+           { // 11
+                   "[32.193s][info][gc,heap     ] GC(2)  Capacity:     1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)     ",
+                   "[32.193s][info][gc,heap     ] GC(2)      Free:    28128M (98%)       28110M (98%)       28148M (98%)       28560M (100%)      28560M (100%)      28108M (98%)    ",
+                   "[32.193s][info][gc,heap     ] GC(2)      Used:      558M (2%)          576M (2%)          538M (2%)          126M (0%)          578M (2%)          126M (0%)     ",
+           },
+           { // 12
+                   "[32.193s][info][gc,heap     ] GC(2)      Live:         -                71M (0%)           71M (0%)           71M (0%)             -                  -",
+                   "[32.193s][info][gc,heap     ] GC(2) Allocated:         -                18M (0%)           20M (0%)           18M (0%)             -                  -",
+                   "[32.193s][info][gc,heap     ] GC(2)   Garbage:         -               486M (2%)          446M (2%)           35M (0%)             -                  -",
+           },
+           { // 13
+                   "[32.193s][info][gc,heap     ] GC(2) Reclaimed:         -                  -                40M (0%)          450M (2%)             -                  -",
 
-            {  //   0
-                    "[3.558s][info ][gc,start       ] GC(3) Garbage Collection (Warmup)"
-            },
-            {  //   1
-                    "[3.559s][info ][gc,phases      ] GC(3) Pause Mark Start 0.460ms",
-                    "[3.574s][info ][gc,phases      ] GC(3) Pause Mark End 0.830ms",
-                    "[3.583s][info ][gc,phases      ] GC(3) Pause Relocate Start 0.794ms"
-            },
-            {  //   2
-                    "[3.573s][info ][gc,phases      ] GC(3) Concurrent Mark 14.621ms",
-                    "[3.578s][info ][gc,phases      ] GC(3) Concurrent Process Non-Strong References 3.654ms",
-                    "[3.578s][info ][gc,phases      ] GC(3) Concurrent Reset Relocation Set 0.194ms",
-                    "[3.582s][info ][gc,phases      ] GC(3) Concurrent Select Relocation Set 3.193ms",
-                    "[3.596s][info ][gc,phases      ] GC(3) Concurrent Relocate 12.962ms"
-            },
-            {  //   3
-                    "[3.596s][info ][gc,load        ] GC(3) Load: 4.28/3.95/3.22"
-            },
-            {  //   4
-                    "[3.596s][info ][gc,mmu         ] GC(3) MMU: 2ms/32.7%, 5ms/60.8%, 10ms/80.4%, 20ms/85.4%, 50ms/90.8%, 100ms/95.4%"
-            },
-            {  //   5
-                    "[3.596s][info ][gc,marking     ] GC(3) Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 1 completion(s), 0 continuation(s)"
-            },
-            {  //   6
-                    "[3.596s][info ][gc,reloc       ] GC(3) Relocation: Successful, 6M relocated"
-            },
-            {  //   7
-                    "[3.596s][info ][gc,nmethod     ] GC(3) NMethods: 1163 registered, 0 unregistered"
-            },
-            {  //   8
-                    "[3.596s][info ][gc,metaspace   ] GC(3) Metaspace: 14M used, 15M capacity, 15M committed, 16M reserved"
-            },
-            {  //   9
-                    "[3.596s][info ][gc,ref         ] GC(3) Soft: 391 encountered, 0 discovered, 0 enqueued",
-                    "[3.596s][info ][gc,ref         ] GC(3) Weak: 587 encountered, 466 discovered, 0 enqueued",
-                    "[3.596s][info ][gc,ref         ] GC(3) Final: 799 encountered, 0 discovered, 0 enqueued",
-                    "[3.596s][info ][gc,ref         ] GC(3) Phantom: 33 encountered, 1 discovered, 0 enqueued",
-            },
-            {  //  10
-                    "[3.596s][info ][gc,heap        ] GC(3) Min Capacity: 8M(0%)",
-                    "[3.596s][info ][gc,heap        ] GC(3) Max Capacity: 4096M(100%)",
-                    "[3.596s][info ][gc,heap        ] GC(3) Soft Max Capacity: 4096M(100%)"
-            },
-            {  //  11
-                    "[3.596s][info ][gc,heap        ] GC(3)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low"
-            },
-            {  //  12
-                    "[3.596s][info ][gc,heap        ] GC(3)  Capacity:      936M (23%)        1074M (26%)        1074M (26%)        1074M (26%)        1074M (26%)         936M (23%)",
-                    "[3.596s][info ][gc,heap        ] GC(3)   Reserve:       42M (1%)           42M (1%)           42M (1%)           42M (1%)           42M (1%)           42M (1%)",
-                    "[3.596s][info ][gc,heap        ] GC(3)      Free:     3160M (77%)        3084M (75%)        3852M (94%)        3868M (94%)        3930M (96%)        3022M (74%)",
-                    "[3.596s][info ][gc,heap        ] GC(3)      Used:      894M (22%)         970M (24%)         202M (5%)          186M (5%)         1032M (25%)         124M (3%)"
-            },
-            {  //  13
-                    "[3.596s][info ][gc,heap        ] GC(3)      Live:         -                 8M (0%)            8M (0%)            8M (0%)             -                  -",
-                    "[3.596s][info ][gc,heap        ] GC(3) Allocated:         -               172M (4%)          172M (4%)          376M (9%)             -                  -",
-                    "[3.596s][info ][gc,heap        ] GC(3)   Garbage:         -               885M (22%)         117M (3%)            5M (0%)             -                  -"
-            },
-            {  //  14
-                    "[3.596s][info ][gc,heap        ] GC(3) Reclaimed:         -                  -               768M (19%)         880M (21%)            -                  -"
-            },
-            {  //  15
-                    "[3.596s][info ][gc             ] GC(3) Garbage Collection (Warmup) 894M(22%)->186M(5%)"
-            }
-    };
+           },
+           { // 14
+                   "[32.193s][info][gc          ] GC(2) Garbage Collection (Metadata GC Threshold) 558M(2%)->126M(0%)",
+           }
+   };
 
     private String[] decoratorLines = {
             "[2018-04-04T09:10:00.586-0100][0.018s][1522825800586ms][18ms][10026341461044ns][17738937ns][1375][7427][info][gc] Using Concurrent Mark Sweep",

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
@@ -6,6 +6,7 @@ import com.microsoft.gctoolkit.event.zgc.OccupancySummary;
 import com.microsoft.gctoolkit.event.zgc.ReclaimSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCCycle;
 import com.microsoft.gctoolkit.event.zgc.ZGCMemoryPoolSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCMetaspaceSummary;
 import com.microsoft.gctoolkit.jvm.Diary;
 import org.junit.jupiter.api.Test;
 
@@ -15,96 +16,102 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ZGCParserTest {
-
-
     @Test
     public void infoLevelZGCCycle() {
 
+        String[] eventLogEntries = {
+                "[32.121s][info][gc,start    ] GC(2) Garbage Collection (Metadata GC Threshold)",
+                "[32.121s][info][gc,phases   ] GC(2) Pause Mark Start 0.023ms",
+                "[32.166s][info][gc,phases   ] GC(2) Concurrent Mark 44.623ms",
+                "[32.166s][info][gc,phases   ] GC(2) Pause Mark End 0.029ms",
+                "[32.166s][info][gc,phases   ] GC(2) Concurrent Mark Free 0.001ms",
+                "[32.172s][info][gc,phases   ] GC(2) Concurrent Process Non-Strong References 5.797ms",
+                "[32.172s][info][gc,phases   ] GC(2) Concurrent Reset Relocation Set 0.012ms",
+                "[32.178s][info][gc,phases   ] GC(2) Concurrent Select Relocation Set 6.446ms",
+                "[32.179s][info][gc,phases   ] GC(2) Pause Relocate Start 0.024ms",
+                "[32.193s][info][gc,phases   ] GC(2) Concurrent Relocate 14.013ms",
+                "[32.193s][info][gc,load     ] GC(2) Load: 7.28/6.63/5.01",
+                "[32.193s][info][gc,mmu      ] GC(2) MMU: 2ms/98.2%, 5ms/99.3%, 10ms/99.5%, 20ms/99.7%, 50ms/99.9%, 100ms/99.9%",
+                "[32.193s][info][gc,marking  ] GC(2) Mark: 4 stripe(s), 3 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s)",
+                "[32.193s][info][gc,marking  ] GC(2) Mark Stack Usage: 32M",
+                "[32.193s][info][gc,metaspace] GC(2) Metaspace: 60M used, 60M committed, 1080M reserved",
+                "[32.193s][info][gc,ref      ] GC(2) Soft: 5447 encountered, 0 discovered, 0 enqueued",
+                "[32.193s][info][gc,ref      ] GC(2) Weak: 5347 encountered, 2016 discovered, 810 enqueued",
+                "[32.193s][info][gc,ref      ] GC(2) Final: 1041 encountered, 113 discovered, 105 enqueued",
+                "[32.193s][info][gc,ref      ] GC(2) Phantom: 558 encountered, 501 discovered, 364 enqueued",
+                "[32.193s][info][gc,reloc    ] GC(2) Small Pages: 235 / 470M, Empty: 32M, Relocated: 40M, In-Place: 0",
+                "[32.193s][info][gc,reloc    ] GC(2) Medium Pages: 2 / 64M, Empty: 0M, Relocated: 3M, In-Place: 0",
+                "[32.193s][info][gc,reloc    ] GC(2) Large Pages: 3 / 24M, Empty: 8M, Relocated: 0M, In-Place: 0",
+                "[32.193s][info][gc,reloc    ] GC(2) Forwarding Usage: 13M",
+                "[32.193s][info][gc,heap     ] GC(2) Min Capacity: 8M(0%)",
+                "[32.193s][info][gc,heap     ] GC(2) Max Capacity: 28686M(100%)",
+                "[32.193s][info][gc,heap     ] GC(2) Soft Max Capacity: 28686M(100%)",
+                "[32.193s][info][gc,heap     ] GC(2)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low         ",
+                "[32.193s][info][gc,heap     ] GC(2)  Capacity:     1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)",
+                "[32.193s][info][gc,heap     ] GC(2)      Free:    28128M (98%)       28110M (98%)       28148M (98%)       28560M (100%)      28560M (100%)      28108M (98%)",
+                "[32.193s][info][gc,heap     ] GC(2)      Used:      558M (2%)          576M (2%)          538M (2%)          126M (0%)          578M (2%)          126M (0%)",
+                "[32.193s][info][gc,heap     ] GC(2)      Live:         -                71M (0%)           71M (0%)           71M (0%)             -                  -          ",
+                "[32.193s][info][gc,heap     ] GC(2) Allocated:         -                18M (0%)           20M (0%)           18M (0%)             -                  -          ",
+                "[32.193s][info][gc,heap     ] GC(2)   Garbage:         -               486M (2%)          446M (2%)           35M (0%)             -                  -          ",
+                "[32.193s][info][gc,heap     ] GC(2) Reclaimed:         -                  -                40M (0%)          450M (2%)             -                  -          ",
+                "[32.193s][info][gc          ] GC(2) Garbage Collection (Metadata GC Threshold) 558M(2%)->126M(0%)",
 
-        String[] eventLogEntries = { "[3.558s][info ][gc,start       ] GC(3) Garbage Collection (Warmup)",
-                "[3.559s][info ][gc,phases      ] GC(3) Pause Mark Start 0.460ms",
-                "[3.573s][info ][gc,phases      ] GC(3) Concurrent Mark 14.621ms",
-                "[3.574s][info ][gc,phases      ] GC(3) Pause Mark End 0.830ms",
-                "[3.578s][info ][gc,phases      ] GC(3) Concurrent Process Non-Strong References 3.654ms",
-                "[3.578s][info ][gc,phases      ] GC(3) Concurrent Reset Relocation Set 0.194ms",
-                "[3.582s][info ][gc,phases      ] GC(3) Concurrent Select Relocation Set 3.193ms",
-                "[3.583s][info ][gc,phases      ] GC(3) Pause Relocate Start 0.794ms",
-                "[3.596s][info ][gc,phases      ] GC(3) Concurrent Relocate 12.962ms",
-                "[3.596s][info ][gc,load        ] GC(3) Load: 4.28/3.95/3.22",
-                "[3.596s][info ][gc,mmu         ] GC(3) MMU: 2ms/32.7%, 5ms/60.8%, 10ms/80.4%, 20ms/85.4%, 50ms/90.8%, 100ms/95.4%",
-                "[3.596s][info ][gc,marking     ] GC(3) Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 1 completion(s), 0 continuation(s)",
-                "[3.596s][info ][gc,reloc       ] GC(3) Relocation: Successful, 6M relocated",
-                "[3.596s][info ][gc,nmethod     ] GC(3) NMethods: 1163 registered, 0 unregistered",
-                "[3.596s][info ][gc,metaspace   ] GC(3) Metaspace: 14M used, 15M capacity, 15M committed, 16M reserved",
-                "[3.596s][info ][gc,ref         ] GC(3) Soft: 391 encountered, 0 discovered, 0 enqueued",
-                "[3.596s][info ][gc,ref         ] GC(3) Weak: 587 encountered, 466 discovered, 0 enqueued",
-                "[3.596s][info ][gc,ref         ] GC(3) Final: 799 encountered, 0 discovered, 0 enqueued",
-                "[3.596s][info ][gc,ref         ] GC(3) Phantom: 33 encountered, 1 discovered, 0 enqueued",
-                "[3.596s][info ][gc,heap        ] GC(3) Min Capacity: 8M(0%)",
-                "[3.596s][info ][gc,heap        ] GC(3) Max Capacity: 4096M(100%)",
-                "[3.596s][info ][gc,heap        ] GC(3) Soft Max Capacity: 4096M(100%)",
-                "[3.596s][info ][gc,heap        ] GC(3)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low",
-                "[3.596s][info ][gc,heap        ] GC(3)  Capacity:      936M (23%)        1074M (26%)        1074M (26%)        1074M (26%)        1074M (26%)         936M (23%)",
-                "[3.596s][info ][gc,heap        ] GC(3)   Reserve:       42M (1%)           42M (1%)           42M (1%)           42M (1%)           42M (1%)           42M (1%)",
-                "[3.596s][info ][gc,heap        ] GC(3)      Free:     3160M (77%)        3084M (75%)        3852M (94%)        3868M (94%)        3930M (96%)        3022M (74%)",
-                "[3.596s][info ][gc,heap        ] GC(3)      Used:      894M (22%)         970M (24%)         202M (5%)          186M (5%)         1032M (25%)         124M (3%)",
-                "[3.596s][info ][gc,heap        ] GC(3)      Live:         -                 8M (0%)            8M (0%)            8M (0%)             -                  -",
-                "[3.596s][info ][gc,heap        ] GC(3) Allocated:         -               172M (4%)          172M (4%)          376M (9%)             -                  -",
-                "[3.596s][info ][gc,heap        ] GC(3)   Garbage:         -               885M (22%)         117M (3%)            5M (0%)             -                  -",
-                "[3.596s][info ][gc,heap        ] GC(3) Reclaimed:         -                  -               768M (19%)         880M (21%)            -                  -",
-                "[3.596s][info ][gc             ] GC(3) Garbage Collection (Warmup) 894M(22%)->186M(5%)"
         };
 
         AtomicBoolean eventCreated = new AtomicBoolean(false);
         ZGCParser parser = new ZGCParser(new Diary(), event -> {
             try {
                 ZGCCycle zgc = (ZGCCycle) event;
-                assertEquals(toInt(0.038d,1000), toInt(zgc.getDuration(),1000));
-                assertEquals(toInt(3.558d, 1000), toInt(zgc.getDateTimeStamp().getTimeStamp(), 1000));
-                assertEquals("Warmup", zgc.getGCCause().getLabel());
+                assertEquals(toInt(0.0719d,1000), toInt(zgc.getDuration(),1000));
+                assertEquals(toInt(32.121d, 1000), toInt(zgc.getDateTimeStamp().getTimeStamp(), 1000));
+                assertEquals("Metadata GC Threshold", zgc.getGCCause().getLabel());
 
                 // Durations
-                assertEquals(toInt(3.558d, 1000), toInt(zgc.getPauseMarkStartTimeStamp().getTimeStamp(), 1000));
-                assertEquals(toInt(3.558d, 1000), toInt(zgc.getConcurrentMarkTimeStamp().getTimeStamp(), 1000));
-                assertEquals(toInt(3.573d, 1000), toInt(zgc.getPauseMarkEndTimeStamp().getTimeStamp(), 1000));
-                assertEquals(toInt(3.574d, 1000), toInt(zgc.getConcurrentProcessNonStrongReferencesTimeStamp().getTimeStamp(), 1000));
-                assertEquals(toInt(3.577d, 1000), toInt(zgc.getConcurrentResetRelocationSetTimeStamp().getTimeStamp(), 1000));
-                assertEquals(toInt(3.578d, 1000), toInt(zgc.getConcurrentSelectRelocationSetTimeStamp().getTimeStamp(), 1000));
-                assertEquals(toInt(3.582d, 1000), toInt(zgc.getPauseRelocateStartTimeStamp().getTimeStamp(), 1000));
-                assertEquals(toInt(3.583d, 1000), toInt(zgc.getConcurrentRelocateTimeStamp().getTimeStamp(), 1000));
+                assertEquals(toInt(32.120977d, 1000), toInt(zgc.getPauseMarkStartTimeStamp().getTimeStamp(), 1000));
+                assertEquals(toInt(32.121377d, 1000), toInt(zgc.getConcurrentMarkTimeStamp().getTimeStamp(), 1000));
+                assertEquals(toInt(32.165999d, 1000), toInt(zgc.getConcurrentMarkFreeTimeStamp().getTimeStamp(), 1000));
+                assertEquals(toInt(32.165971d, 1000), toInt(zgc.getPauseMarkEndTimeStamp().getTimeStamp(), 1000));
+                assertEquals(toInt(32.166203d, 1000), toInt(zgc.getConcurrentProcessNonStrongReferencesTimeStamp().getTimeStamp(), 1000));
+                assertEquals(toInt(32.171988d, 1000), toInt(zgc.getConcurrentResetRelocationSetTimeStamp().getTimeStamp(), 1000));
+                assertEquals(toInt(32.171554d, 1000), toInt(zgc.getConcurrentSelectRelocationSetTimeStamp().getTimeStamp(), 1000));
+                assertEquals(toInt(32.178976d, 1000), toInt(zgc.getPauseRelocateStartTimeStamp().getTimeStamp(), 1000));
+                assertEquals(toInt(32.178987d, 1000), toInt(zgc.getConcurrentRelocateTimeStamp().getTimeStamp(), 1000));
 
-                assertEquals( toInt(0.460d, 1000), toInt(zgc.getPauseMarkStartDuration(), 1000));
-                assertEquals(toInt(14.621d, 1000), toInt(zgc.getConcurrentMarkDuration(), 1000));
-                assertEquals( toInt(0.830d, 1000), toInt(zgc.getPauseMarkEndDuration(), 1000));
-                assertEquals( toInt(3.654d, 1000), toInt(zgc.getConcurrentProcessNonStrongReferencesDuration(), 1000));
-                assertEquals( toInt(0.194d, 1000), toInt(zgc.getConcurrentResetRelocationSetDuration(), 1000));
-                assertEquals( toInt(3.193d, 1000), toInt(zgc.getConcurrentSelectRelocationSetDuration(), 1000));
-                assertEquals( toInt(0.794d, 1000), toInt(zgc.getPauseRelocateStartDuration(), 1000));
-                assertEquals(toInt(12.962d, 1000), toInt(zgc.getConcurrentRelocateDuration(), 1000));
+                assertEquals(toInt(0.023d, 1000), toInt(zgc.getPauseMarkStartDuration(), 1000));
+                assertEquals(toInt(44.623d, 1000), toInt(zgc.getConcurrentMarkDuration(), 1000));
+                assertEquals(toInt(0.001d, 1000), toInt(zgc.getConcurrentMarkFreeDuration(), 1000));
+                assertEquals(toInt(0.029d, 1000), toInt(zgc.getPauseMarkEndDuration(), 1000));
+                assertEquals(toInt(5.797d, 1000), toInt(zgc.getConcurrentProcessNonStrongReferencesDuration(), 1000));
+                assertEquals(toInt(0.012d, 1000), toInt(zgc.getConcurrentResetRelocationSetDuration(), 1000));
+                assertEquals(toInt(6.446d, 1000), toInt(zgc.getConcurrentSelectRelocationSetDuration(), 1000));
+                assertEquals(toInt(0.024d, 1000), toInt(zgc.getPauseRelocateStartDuration(), 1000));
+                assertEquals(toInt(14.013d, 1000), toInt(zgc.getConcurrentRelocateDuration(), 1000));
 
                 //Memory
-                assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkStart(), 958464, 43008, 3235840, 915456));
-                assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkEnd(), 1099776, 43008, 3158016, 993280));
-                assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateStart(),1099776, 43008, 3944448, 206848));
-                assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateEnd(), 1099776, 43008, 3960832, 190464));
+                assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkStart(), 1837056, 28803072, 571392));
+                assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkEnd(), 1837056, 28784640, 589824 ));
+                assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateStart(),1837056, 28823552, 550912));
+                assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateEnd(), 1837056, 29245440, 129024));
 
-                assertTrue(checkOccupancySummary(zgc.getLive(), 8192, 8192, 8192));
-                assertTrue(checkOccupancySummary(zgc.getAllocated(), 176128, 176128, 385024));
-                assertTrue(checkOccupancySummary(zgc.getGarbage(), 906240, 119808, 5120));
+                assertTrue(checkZGCMetaSpaceSummary(zgc.getMetaspace(),61440, 61440, 1105920));
 
-                assertTrue(checkReclaimSummary(zgc.getReclaimed(), 768L, 880L));
-                assertTrue(checkReclaimSummary(zgc.getMemorySummary(), 894L, 186L));
+                assertTrue(checkOccupancySummary(zgc.getLive(), 72704, 72704, 72704));
+                assertTrue(checkOccupancySummary(zgc.getAllocated(), 18432, 20480, 18432));
+                assertTrue(checkOccupancySummary(zgc.getGarbage(), 497664, 456704, 35840));
 
-                assertEquals(4.28, zgc.getLoadAverageAt(1));
-                assertEquals(3.95, zgc.getLoadAverageAt(5));
-                assertEquals(3.22, zgc.getLoadAverageAt(15));
+                assertTrue(checkReclaimSummary(zgc.getReclaimed(), 40960, 460800));
+                assertTrue(checkReclaimSummary(zgc.getMemorySummary(), 571392, 129024));
 
-                assertEquals(32.7, zgc.getMMU(2));
-                assertEquals(60.8, zgc.getMMU(5));
-                assertEquals(80.4, zgc.getMMU(10));
-                assertEquals(85.4, zgc.getMMU(20));
-                assertEquals(90.8, zgc.getMMU(50));
-                assertEquals(95.4, zgc.getMMU(100));
+                assertEquals(7.28, zgc.getLoadAverageAt(1));
+                assertEquals(6.63, zgc.getLoadAverageAt(5));
+                assertEquals(5.01, zgc.getLoadAverageAt(15));
+
+                assertEquals(98.2, zgc.getMMU(2));
+                assertEquals(99.3, zgc.getMMU(5));
+                assertEquals(99.5, zgc.getMMU(10));
+                assertEquals(99.7, zgc.getMMU(20));
+                assertEquals(99.9, zgc.getMMU(50));
+                assertEquals(99.9, zgc.getMMU(100));
 
             } catch (Throwable t) {
                 fail(t);
@@ -117,8 +124,12 @@ public class ZGCParserTest {
 
     }
 
-    private boolean checkZGCMemoryPoolSummary(ZGCMemoryPoolSummary summary, long capacity, long reserved, long free, long used) {
-        return summary.getCapacity() == capacity && summary.getReserved() == reserved && summary.getFree() == free && summary.getUsed() == used;
+    private boolean checkZGCMetaSpaceSummary(ZGCMetaspaceSummary summary, long used, long committed, long reserved) {
+        return summary.getUsed() == used && summary.getCommitted() == committed && summary.getReserved() == reserved;
+    }
+
+    private boolean checkZGCMemoryPoolSummary(ZGCMemoryPoolSummary summary, long capacity, long free, long used) {
+        return summary.getCapacity() == capacity && summary.getFree() == free && summary.getUsed() == used;
     }
 
     private boolean checkOccupancySummary(OccupancySummary summary, long markEnd, long relocateStart, long relocateEnd) {


### PR DESCRIPTION
ZGC was marked production ready in Java 17. There were a number of changes made to the ZGC log output in the past 2-3 years that have made it into the 17 release. I've updated the tests with samples from a Java 17 run on a sample app to test changes made to the ZGCCycle class.  Java sample app was invoked with the following flag `-Xlog:gc=info,gc+start=info,gc+phases=info,gc+load=info,gc+mmu=info,gc+marking=info,gc+metaspace=info,gc+nmethod=info,gc+ref=info,gc+reloc=info,gc+heap=info:file=/logs/gclog:level,tags,uptime:filecount=10,filesize=250m`

* elastic metaspace was introduced in this commit https://github.com/openjdk/zgc/commit/7ba6a6bf003b810e9f48cb755abe39b1376ad3fe#diff-9aa1419e172b665d42f187e7f9d46753f396ab6e0d192906d659ff81b3b6cf12 which removes the capacity field. A specific metaspace class was added to reflect these changes.

* Memory pool summary no longer emits reserved heap, removed to reflect changes in this file https://github.com/openjdk/zgc/blob/1f8813495e8184b6c38319df1c2cb70de7811a76/src/hotspot/share/gc/z/zStat.cpp#L1432-L1503

* MarkFree phase was added and exported in the ZGCCycle summary. May be opportunity to add Mark Continue phase in the future. Phase are defined here https://github.com/openjdk/zgc/blob/26c03c1860c6da450b5cd6a46576c78bea682f96/src/hotspot/share/gc/z/zDriver.cpp#L45-L54

* Reclaimed and MemorySummary were updated to export value in kilobytes based on the unit strings

* Relocation summary is not yet implemented so it was removed form the ZGCParserRulesTest class as the old capture doesn't work with the new format. I'll update this in a separate PR.

* ZGCParserTest was update with a new format, along with all test values, that were hand calculate to ensure we're accurately parsing the data.