### PR TITLE
[ZGC] Add GC ID to the ZGCCycle

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
@@ -24,6 +24,8 @@ public class ZGCCycle extends GCEvent {
         super(timeStamp, gcType, duration);
     }
 
+    private long gcId;
+
     private DateTimeStamp pauseMarkStartTimeStamp;
     private double pauseMarkStartDuration;
 
@@ -63,6 +65,14 @@ public class ZGCCycle extends GCEvent {
     public void setPauseMarkStart(DateTimeStamp pauseMarkStartTimeStamp, double duration) {
         this.pauseMarkStartTimeStamp = pauseMarkStartTimeStamp;
         this.pauseMarkStartDuration = duration;
+    }
+
+    public long getGcId() {
+        return gcId;
+    }
+
+    public void setGcId(long gcId) {
+        this.gcId = gcId;
     }
 
     public DateTimeStamp getConcurrentMarkTimeStamp() {

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
@@ -108,7 +108,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     }
 
     private void cycleStart(GCLogTrace trace, String s) {
-        forwardReference = new ZGCForwardReference(getClock(), trace.gcCause(0, 1));
+        forwardReference = new ZGCForwardReference(getClock(), trace.getLongGroup(1), trace.gcCause(1, 1));
     }
 
     private void pausePhase(GCLogTrace trace, String s) {
@@ -271,6 +271,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     private class ZGCForwardReference {
         private final DateTimeStamp startTimeStamp;
         private final GCCause gcCause;
+        private final long gcId;
 
         // Timing
         private DateTimeStamp pauseMarkStart;
@@ -307,13 +308,15 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         private double[] mmu = new double[6];
 
 
-        public ZGCForwardReference(DateTimeStamp dateTimeStamp, GCCause cause) {
+        public ZGCForwardReference(DateTimeStamp dateTimeStamp, long gcId, GCCause cause) {
             this.startTimeStamp = dateTimeStamp;
+            this.gcId = gcId;
             gcCause = cause;
         }
 
         ZGCCycle toZGCCycle(DateTimeStamp endTime) {
             ZGCCycle cycle = new ZGCCycle(startTimeStamp, gcCause, endTime.minus(startTimeStamp));
+            cycle.setGcId(gcId);
             cycle.setPauseMarkStart(pauseMarkStart, pauseMarkStartDuration);
             cycle.setConcurrentMark(concurrentMarkStart, concurrentMarkDuration);
             cycle.setPauseMarkEnd(pauseMarkEndStart, pauseMarkEndDuration);

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
@@ -12,7 +12,7 @@ public interface ZGCPatterns extends UnifiedPatterns {
     GCParseRule ZGC_TAG = new GCParseRule("ZGC Tag", "Initializing The Z Garbage Collector$");
 
     //[3.558s][info ][gc,start       ] GC(3) Garbage Collection (Warmup)
-    GCParseRule CYCLE_START = new GCParseRule("CYCLE_START", "Garbage Collection " + GenericTokens.GC_CAUSE + "$");
+    GCParseRule CYCLE_START = new GCParseRule("CYCLE_START", "GC\\(" + GenericTokens.INT + "\\) Garbage Collection " + GenericTokens.GC_CAUSE + "$");
 
     //[3.559s][info ][gc,phases      ] GC(3) Pause Mark Start 0.460ms
     //[3.574s][info ][gc,phases      ] GC(3) Pause Mark End 0.830ms

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
@@ -59,6 +59,9 @@ public class ZGCParserTest {
         ZGCParser parser = new ZGCParser(new Diary(), event -> {
             try {
                 ZGCCycle zgc = (ZGCCycle) event;
+
+                assertEquals(zgc.getGcId(), 3L);
+
                 assertEquals(toInt(0.038d,1000), toInt(zgc.getDuration(),1000));
                 assertEquals(toInt(3.558d, 1000), toInt(zgc.getDateTimeStamp().getTimeStamp(), 1000));
                 assertEquals("Warmup", zgc.getGCCause().getLabel());


### PR DESCRIPTION
The GC id can be useful when analyzing data and may be valuable to users. It can help order data later or give an indication of how many GC cycles have happened since since the process start or between points in time.

I've plumbed the GC id from the ZGCParser through to the ZGCCycle class. It'll be captured as part of the cycle start regex.