### PR TITLE
An improvement on ParserTest to fix diarization

### DIFF
--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/CMSTenuredParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/CMSTenuredParserTest.java
@@ -11,10 +11,10 @@ import com.microsoft.gctoolkit.event.generational.ConcurrentReset;
 import com.microsoft.gctoolkit.event.generational.ConcurrentSweep;
 import com.microsoft.gctoolkit.event.generational.InitialMark;
 import com.microsoft.gctoolkit.event.jvm.JVMEvent;
+import com.microsoft.gctoolkit.jvm.Diarizer;
 import com.microsoft.gctoolkit.parser.CMSTenuredPoolParser;
 import com.microsoft.gctoolkit.parser.GCLogParser;
 import com.microsoft.gctoolkit.parser.jvm.PreUnifiedDiarizer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -23,14 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class CMSTenuredParserTest extends ParserTest {
+    
+    protected Diarizer diarizer() {
+        return new PreUnifiedDiarizer();
+    }
 
-    private CMSTenuredPoolParser parser;
-    private List<JVMEvent> jvmEvents;
-
-    @BeforeEach
-    public void setUp() {
-        parser = new CMSTenuredPoolParser();
-        jvmEvents = super.setup(parser, new PreUnifiedDiarizer().getDiary()).events();
+    @Override
+    protected GCLogParser parser() {
+        return new CMSTenuredPoolParser();
     }
 
     @Test
@@ -53,7 +53,7 @@ public class CMSTenuredParserTest extends ParserTest {
                 GCLogParser.END_OF_DATA_SENTINEL
         };
 
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
         try {
             InitialMark initialMark = (InitialMark) jvmEvents.get(0);
@@ -84,7 +84,7 @@ public class CMSTenuredParserTest extends ParserTest {
                 GCLogParser.END_OF_DATA_SENTINEL
         };
 
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
         try {
             InitialMark initialMark = (InitialMark) jvmEvents.get(0);
@@ -120,7 +120,7 @@ public class CMSTenuredParserTest extends ParserTest {
                 GCLogParser.END_OF_DATA_SENTINEL
         };
 
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
         try {
             InitialMark initialMark = (InitialMark) jvmEvents.get(0);
@@ -162,7 +162,7 @@ public class CMSTenuredParserTest extends ParserTest {
                 "2020-03-27T17:40:46.829+0000: 62609.842: [CMS-concurrent-abortable-preclean: 2.855/3.180 secs] [Times: user=25.14 sys=1.51, real=3.18 secs] "
         };
         
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
         try {
             ConcurrentMark concurrentMark = (ConcurrentMark) jvmEvents.get(0);

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/GenerationalParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/GenerationalParserTest.java
@@ -14,6 +14,8 @@ import com.microsoft.gctoolkit.event.generational.ParNewPromotionFailed;
 import com.microsoft.gctoolkit.event.generational.SystemGC;
 import com.microsoft.gctoolkit.event.jvm.JVMEvent;
 import com.microsoft.gctoolkit.io.GCLogFile;
+import com.microsoft.gctoolkit.jvm.Diarizer;
+import com.microsoft.gctoolkit.parser.GCLogParser;
 import com.microsoft.gctoolkit.parser.GenerationalHeapParser;
 import com.microsoft.gctoolkit.parser.jvm.PreUnifiedDiarizer;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,15 +30,13 @@ public class GenerationalParserTest extends ParserTest {
 
     private static final String END_OF_DATA_SENTINEL = GCLogFile.END_OF_DATA_SENTINEL;
 
-    private ParserTestSupportChannel channel;
-    private GenerationalHeapParser parser;
-    private List<JVMEvent> collection;
+    protected Diarizer diarizer() {
+        return new PreUnifiedDiarizer();
+    };
 
-    @BeforeEach
-    public void setUp() {
-        parser = new GenerationalHeapParser();
-        collection = super.setup(parser, new PreUnifiedDiarizer().getDiary()).events();
-    }
+    protected GCLogParser parser() {
+        return new GenerationalHeapParser();
+    };
 
     @Test
     public void testDefNewDetails() {
@@ -46,9 +46,9 @@ public class GenerationalParserTest extends ParserTest {
                 END_OF_DATA_SENTINEL
         };
 
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
-        DefNew defNew = (DefNew) collection.get(0);
+        DefNew defNew = (DefNew) jvmEvents.get(0);
 
         // occupancy before(size before)->occupancy after(size)
         assertMemoryPoolValues(defNew.getHeap(), 502104, 2044800, 102148, 2044800);
@@ -77,24 +77,24 @@ public class GenerationalParserTest extends ParserTest {
                 END_OF_DATA_SENTINEL
         };
 
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
-        ParNew parNew = (ParNew) collection.get(0);
+        ParNew parNew = (ParNew) jvmEvents.get(0);
         assertMemoryPoolValues(parNew.getHeap(), 16000, 81280, 1725, 81280);
         assertMemoryPoolValues(parNew.getYoung(), 16000, 18624, 1725, 18624);
         assertMemoryPoolValues(parNew.getTenured(), 0, 81280 - 18624, 0, 81280 - 18624);
         assertEquals(0.0167922, parNew.getDuration());
 
-        SystemGC full = (SystemGC) collection.get(1);
+        SystemGC full = (SystemGC) jvmEvents.get(1);
         assertMemoryPoolValues(full.getHeap(), 4654, 81280, 1602, 81280);
         assertMemoryPoolValues(full.getYoung(), 4654, 81280 - 62656, 0, 81280 - 62656);
         assertMemoryPoolValues(full.getTenured(), 0, 81280 - 18624, 1602, 62656);
         assertEquals(0.0712086, full.getDuration());
 
-        parNew = (ParNew) collection.get(2);
+        parNew = (ParNew) jvmEvents.get(2);
         assertEquals(81280, parNew.getHeap().getSizeAfterCollection());
 
-        parNew = (ParNew) collection.get(3);
+        parNew = (ParNew) jvmEvents.get(3);
         assertEquals(81280, parNew.getHeap().getSizeAfterCollection());
     }
 
@@ -119,11 +119,11 @@ public class GenerationalParserTest extends ParserTest {
         };
 
 
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
-        InitialMark initialMark = (InitialMark) collection.get(0);
-        ParNewPromotionFailed parNewPromotionFailed = (ParNewPromotionFailed) collection.get(1);
-        ConcurrentModeFailure concurrentModeFailure = (ConcurrentModeFailure) collection.get(2);
+        InitialMark initialMark = (InitialMark) jvmEvents.get(0);
+        ParNewPromotionFailed parNewPromotionFailed = (ParNewPromotionFailed) jvmEvents.get(1);
+        ConcurrentModeFailure concurrentModeFailure = (ConcurrentModeFailure) jvmEvents.get(2);
     }
 
     @Test
@@ -136,16 +136,16 @@ public class GenerationalParserTest extends ParserTest {
                 END_OF_DATA_SENTINEL
         };
 
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
-        PSYoungGen psYoungGen = (PSYoungGen) collection.get(0);
+        PSYoungGen psYoungGen = (PSYoungGen) jvmEvents.get(0);
         assertSame(psYoungGen.getGCCause(), GCCause.ALLOCATION_FAILURE);
         assertEquals(0.0485326, psYoungGen.getDuration());
         assertMemoryPoolValues(psYoungGen.getHeap(), 610571, 819712, 581588, 819712);
         assertMemoryPoolValues(psYoungGen.getTenured(), 610571 - 232960, 819712 - 232960, 581588 - 116224, 819712 - 232960);
         assertMemoryPoolValues(psYoungGen.getYoung(), 232960, 232960, 116224, 232960);
 
-        FullGC fullGC = (FullGC) collection.get(1);
+        FullGC fullGC = (FullGC) jvmEvents.get(1);
         assertSame(fullGC.getGCCause(), GCCause.ADAPTIVE_SIZE_POLICY);
         assertEquals(0.0449697, fullGC.getDuration());
         // todo: value of heap size before collection is 808448 should be 819712.
@@ -174,19 +174,19 @@ public class GenerationalParserTest extends ParserTest {
                 END_OF_DATA_SENTINEL
         };
 
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
-        ParNew parNew = (ParNew) collection.get(0);
+        ParNew parNew = (ParNew) jvmEvents.get(0);
         assertSame(parNew.getGCCause(), GCCause.GC_LOCKER);
         assertMemoryPoolValues(parNew.getHeap(), 35230, 354944, 38078, 354944);
         assertMemoryPoolValues(parNew.getYoung(), 32671, 349568, 35386, 349568);
         assertMemoryPoolValues(parNew.getTenured(), 35230 - 32671, 354944 - 349568, 38078 - 35386, 354944 - 349568);
         assertEquals(0.0082790, parNew.getDuration());
 
-        InitialMark initialMark = (InitialMark) collection.get(1);
+        InitialMark initialMark = (InitialMark) jvmEvents.get(1);
         assertSame(initialMark.getGCCause(), GCCause.CMS_INITIAL_MARK);
 
-        CMSRemark cmsRemark = (CMSRemark) collection.get(2);
+        CMSRemark cmsRemark = (CMSRemark) jvmEvents.get(2);
         assertSame(cmsRemark.getGCCause(), GCCause.CMS_FINAL_REMARK);
         assertEquals(0.0699640, cmsRemark.getDuration());
     }
@@ -210,18 +210,18 @@ public class GenerationalParserTest extends ParserTest {
                 END_OF_DATA_SENTINEL
         };
 
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
 
-        ParNew parNew = (ParNew) collection.get(0);
+        ParNew parNew = (ParNew) jvmEvents.get(0);
         assertMemoryPoolValues(parNew.getHeap(), 1856305, 1965056, 851287, 1965056);
         assertMemoryPoolValues(parNew.getYoung(), 1143174, 1188864, 132096, 1188864);
         assertMemoryPoolValues(parNew.getTenured(), 1856305 - 1143174, 1965056 - 1188864, 851287 - 132096, 1965056 - 1188864);
         assertEquals(0.1554100, parNew.getDuration());
 
-        InitialMark initialMark = (InitialMark) collection.get(1);
+        InitialMark initialMark = (InitialMark) jvmEvents.get(1);
         assertEquals(0.1976100, initialMark.getDuration());
 
-        CMSRemark cmsRemark = (CMSRemark) collection.get(2);
+        CMSRemark cmsRemark = (CMSRemark) jvmEvents.get(2);
         assertEquals(0.6306470, cmsRemark.getDuration());
     }
 }

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/ParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/ParserTest.java
@@ -29,6 +29,7 @@ public abstract class ParserTest {
         channel = new ParserTestSupportChannel();
         diarizer = diarizer();
         parser = parser();
+        parser.diary(diarizer.getDiary());
         parser.publishTo(channel);
     }
 
@@ -52,10 +53,7 @@ public abstract class ParserTest {
      */
     protected List<JVMEvent> feedParser(String[] lines) {
         Arrays.stream(lines).forEach(diarizer::diarize);
-        parser.diary(diarizer.getDiary());
-
         Arrays.stream(lines).map(String::trim).forEach(parser::receive);
-
         return channel.events();
     }
 

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/ParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/ParserTest.java
@@ -22,11 +22,14 @@ public abstract class ParserTest {
 
     private Diarizer diarizer;
     private GCLogParser parser;
+    private ParserTestSupportChannel  channel;
 
     @BeforeEach
     public void setUp() {
-        parser = parser();
+        channel = new ParserTestSupportChannel();
         diarizer = diarizer();
+        parser = parser();
+        parser.publishTo(channel);
     }
 
     /**
@@ -44,15 +47,12 @@ public abstract class ParserTest {
     /**
      * Parser runs in its own thread so start one for it and then feed it the lines to be parsed
      *
-     * @param lines
-     * @return
+     * @param lines The GC log lines to be fed to the parser.
+     * @return The list of JVMEvents from the parsed lines.
      */
     protected List<JVMEvent> feedParser(String[] lines) {
         Arrays.stream(lines).forEach(diarizer::diarize);
         parser.diary(diarizer.getDiary());
-
-        ParserTestSupportChannel  channel = new ParserTestSupportChannel();
-        parser.publishTo(channel);
 
         Arrays.stream(lines).map(String::trim).forEach(parser::receive);
 

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/ParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/ParserTest.java
@@ -48,9 +48,6 @@ public abstract class ParserTest {
      * @return
      */
     protected List<JVMEvent> feedParser(String[] lines) {
-        Diarizer diarizer = diarizer();
-        GCLogParser parser = parser();
-
         Arrays.stream(lines).forEach(diarizer::diarize);
         parser.diary(diarizer.getDiary());
 

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/ParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/ParserTest.java
@@ -5,11 +5,12 @@ package com.microsoft.gctoolkit.parser.patterns;
 
 import com.microsoft.gctoolkit.event.MemoryPoolSummary;
 import com.microsoft.gctoolkit.event.jvm.JVMEvent;
-import com.microsoft.gctoolkit.jvm.Diary;
+import com.microsoft.gctoolkit.jvm.Diarizer;
 import com.microsoft.gctoolkit.message.Channels;
 import com.microsoft.gctoolkit.message.JVMEventChannel;
 import com.microsoft.gctoolkit.message.JVMEventChannelListener;
 import com.microsoft.gctoolkit.parser.GCLogParser;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,24 +18,48 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ParserTest {
+public abstract class ParserTest {
 
-    protected ParserTestSupportChannel setup(GCLogParser parser, Diary diary) {
-        ParserTestSupportChannel  channel = new ParserTestSupportChannel();
-        parser.publishTo(channel);
-        parser.diary(diary);
-        return channel;
+    private Diarizer diarizer;
+    private GCLogParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        parser = parser();
+        diarizer = diarizer();
     }
 
+    /**
+     * The test provides an instance of a Diarizer appropriate to the gc log or lines being parsed.
+     * @return A Diarizer appropriate to the gc log or lines being parsed
+     */
+    protected abstract Diarizer diarizer();
 
     /**
-     * Parser runs in it's own thread so start one for it and then feed it the lines to be parsed
-     *
-     * @param parser
-     * @param lines
+     * The test provides an instance of a GCLogParser appropriate to the gc log or lines being parsed.
+     * @return A GCLogParser appropriate to the gc log or lines being parsed
      */
-    protected void feedParser(GCLogParser parser, String[] lines) {
+    protected abstract GCLogParser parser();
+
+    /**
+     * Parser runs in its own thread so start one for it and then feed it the lines to be parsed
+     *
+     * @param lines
+     * @return
+     */
+    protected List<JVMEvent> feedParser(String[] lines) {
+        Diarizer diarizer = diarizer();
+        GCLogParser parser = parser();
+
+        Arrays.stream(lines).forEach(diarizer::diarize);
+        parser.diary(diarizer.getDiary());
+
+        ParserTestSupportChannel  channel = new ParserTestSupportChannel();
+        parser.publishTo(channel);
+
         Arrays.stream(lines).map(String::trim).forEach(parser::receive);
+
+        return channel.events();
     }
 
     /**

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/UnifiedGenerationalEventsTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/patterns/UnifiedGenerationalEventsTest.java
@@ -17,34 +17,29 @@ import com.microsoft.gctoolkit.event.generational.PSFullGC;
 import com.microsoft.gctoolkit.event.generational.PSYoungGen;
 import com.microsoft.gctoolkit.event.generational.ParNew;
 import com.microsoft.gctoolkit.event.jvm.JVMEvent;
-import com.microsoft.gctoolkit.jvm.Diary;
+import com.microsoft.gctoolkit.jvm.Diarizer;
+import com.microsoft.gctoolkit.parser.GCLogParser;
 import com.microsoft.gctoolkit.parser.UnifiedGenerationalParser;
 import com.microsoft.gctoolkit.parser.jvm.UnifiedDiarizer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class UnifiedGenerationalEventsTest extends ParserTest {
 
-    private List<JVMEvent> jvmEvents;
-    private UnifiedGenerationalParser parser;
+    @Override
+    protected Diarizer diarizer() {
+        return new UnifiedDiarizer();
+    }
 
-//    private Diary getDiary(String[] input) {
-//        UnifiedDiarizer configuration = new UnifiedDiarizer();
-//        Arrays.stream(input).forEach(configuration::diarize);
-//        return configuration.getDiary();
-//    }
-
-    @BeforeEach
-    public void setUp() {
-        parser = new UnifiedGenerationalParser();
-        jvmEvents = super.setup(parser, new UnifiedDiarizer().getDiary()).events();
+    @Override
+    protected GCLogParser parser() {
+        return new UnifiedGenerationalParser();
     }
 
     @Test
@@ -62,7 +57,7 @@ public class UnifiedGenerationalEventsTest extends ParserTest {
                 "[10.026s][info ][gc           ] GC(0) Pause Young (Allocation Failure) 16M->4M(61M) 5.423ms",
                 "[10.026s][info ][gc,cpu       ] GC(0) User=0.02s Sys=0.01s Real=0.00s",
         };
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
         try {
             assertEquals(1, jvmEvents.size(), "Should be 1 event... ");
             PSYoungGen youngGen = (PSYoungGen) jvmEvents.get(0);
@@ -121,7 +116,7 @@ public class UnifiedGenerationalEventsTest extends ParserTest {
                 "[10.130s][info ][gc             ] GC(25) Pause Full (Ergonomics) 55M->7M(42M) 14.092ms",
                 "[10.130s][info ][gc,cpu         ] GC(25) User=0.04s Sys=0.00s Real=0.02s"
         };
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
         try {
             assertEquals(1, jvmEvents.size(), "Should be 1 event... ");
             PSFullGC full = (PSFullGC) jvmEvents.get(0);
@@ -149,8 +144,7 @@ public class UnifiedGenerationalEventsTest extends ParserTest {
                 "[31.193s][info ][gc,cpu       ] GC(17) User=0.01s Sys=0.00s Real=0.00s"
         };
 
-        //feedParser(new UnifiedGenerationalParser(getDiary(lines), event -> jvmEvents.add(event)), lines);
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
         try {
             assertEquals(1, jvmEvents.size());
             ParNew collection = (ParNew) jvmEvents.get(0);
@@ -214,7 +208,7 @@ public class UnifiedGenerationalEventsTest extends ParserTest {
                 "[31.276s][info ][gc           ] GC(29) Concurrent Reset 2.716ms",
                 "[31.276s][info ][gc,cpu       ] GC(29) User=0.01s Sys=0.00s Real=0.00s"
         };
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
         try {
             assertEquals(7, jvmEvents.size());
             InitialMark initialMark = (InitialMark) jvmEvents.get(0);
@@ -256,8 +250,7 @@ public class UnifiedGenerationalEventsTest extends ParserTest {
                 "[11.910s][info ][gc           ] GC(0) Pause Young (Allocation Failure) 16M->3M(61M) 10.585ms",
                 "[11.910s][info ][gc,cpu       ] GC(0) User=0.01s Sys=0.00s Real=0.01s"
         };
-        feedParser(parser, lines);
-        //feedParser(new UnifiedGenerationalParser(getDiary(lines)),lines); //, event -> jvmEvents.add(event)), lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
         try {
             assertEquals(1, jvmEvents.size());
             DefNew collection = (DefNew) jvmEvents.get(0);
@@ -313,9 +306,7 @@ public class UnifiedGenerationalEventsTest extends ParserTest {
                 "[12.199s][info ][gc             ] GC(112) Pause Young (Allocation Failure) 61M->6M(61M) 10.878ms",
                 "[12.199s][info ][gc,cpu         ] GC(112) User=0.02s Sys=0.00s Real=0.01s"
         };
-        //feedParser(new UnifiedGenerationalParser(getDiary(lines)),lines); //, event -> jvmEvents.add(event)), lines);
-        //parser.diary(getDiary(lines));
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
         try {
             assertEquals(1, jvmEvents.size());
             FullGC collection = (FullGC) jvmEvents.get(0);
@@ -338,8 +329,7 @@ public class UnifiedGenerationalEventsTest extends ParserTest {
                 "[0.694s][info][gc           ] GC(2) Pause Young (Allocation Failure) 116M->115M(171M) 131.613ms",
                 "[0.694s][info][gc,cpu       ] GC(2) User=0.33s Sys=0.02s Real=0.13s"
         };
-        //feedParser(new UnifiedGenerationalParser(getDiary(lines)), lines); //, event -> jvmEvents.add(event)), lines);
-        feedParser(parser, lines);
+        List<JVMEvent> jvmEvents = feedParser(lines);
         try {
             assertEquals(1, jvmEvents.size());
             PSYoungGen collection = (PSYoungGen) jvmEvents.get(0);


### PR DESCRIPTION
@kcpeppe - I took a swipe at fixing the diarization issue in ParserTest. Basically, the setUp() method didn't have access to the String[] lines to create the diary. I pushed setUp() up into ParserTest and introduced two abstract methods - one to get the Diarizer, the other to get the GCLogParser. I then changed the feedParser method so that it only takes the String[] lines. All of the diarization and channel setup is done in feedParser(String lines), which also cleans up the redundant code in the three tests that use ParserTest at the moment. 