### PR TITLE
Bumped up vert.x version to fix netty vulnerability CVE-2022-41915.

### DIFF
--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>4.3.4</version>
+            <version>4.3.7</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Please test and release a new build on Maven Central ASAP.

https://github.com/netty/netty/security/advisories/GHSA-hh82-3pmq-7frp

And then send out a security advisory to upgrade to the latest version of GCToolkit.