### PR TITLE
Aggregator completion thread needs to be daemon

### DIFF
--- a/vertx/src/main/java/com/microsoft/gctoolkit/vertx/DataSourceVerticle.java
+++ b/vertx/src/main/java/com/microsoft/gctoolkit/vertx/DataSourceVerticle.java
@@ -44,11 +44,6 @@ public class DataSourceVerticle extends AbstractVerticle {
     }
 
     @Override
-    public void stop(Promise promise) {
-        promise.complete();
-    }
-
-    @Override
     public boolean equals(Object other) {
         // we want Object.equals(other) because it's ok to have more than 1 AggregatorEngine on the bus
         // just not the same AggregatorEngine multiple times over and over redundantly

--- a/vertx/src/main/java/com/microsoft/gctoolkit/vertx/JVMEventVerticle.java
+++ b/vertx/src/main/java/com/microsoft/gctoolkit/vertx/JVMEventVerticle.java
@@ -46,11 +46,6 @@ public class JVMEventVerticle extends AbstractVerticle {
     }
 
     @Override
-    public void stop(Promise promise) {
-        promise.complete();
-    }
-
-    @Override
     public boolean equals(Object other) {
         // we want Object.equals(other) because it's ok to have more than 1 AggregatorEngine on the bus
         // just not the same AggregatorEngine multiple times over and over redundantly


### PR DESCRIPTION
Aggregator uses Executors.newSingleThreadExecutor() to execute the onCompletion task. This creates a non-daemon thread which prevents the JVM from exiting. 