### PR TITLE
Order keys by mru parse rule

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedSurvivorMemoryPoolParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedSurvivorMemoryPoolParser.java
@@ -52,8 +52,10 @@ public class UnifiedSurvivorMemoryPoolParser extends UnifiedGCLogParser implemen
         } else if ((trace = AGE_TABLE_HEADER.parse(entry)) != null) {
             //we've collected this data so.. eat it...
         } else if ((trace = AGE_RECORD.parse(entry)) != null) {
-            forwardReference.add(trace.getIntegerGroup(1), trace.getLongGroup(2));
-            ageDataCollected = true;
+            if (forwardReference != null) {
+                forwardReference.add(trace.getIntegerGroup(1), trace.getLongGroup(2));
+                ageDataCollected = true;
+            }
         } else if (entry.equals(END_OF_DATA_SENTINEL) || (JVM_EXIT.parse(entry) != null)) {
             if (forwardReference != null)
                 publish(forwardReference);

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/collection/RuleSet.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/collection/RuleSet.java
@@ -2,27 +2,45 @@
 // Licensed under the MIT License.
 package com.microsoft.gctoolkit.parser.collection;
 
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public class RuleSet<K, V> implements Map<K, V>, Iterable<K> {
 
-    private final HashMap<K, V> entries;
-    private final LinkedList<K> keys;
+    private static class Node<K, V> extends AbstractMap.SimpleImmutableEntry<K,V> {
+
+        private Node<K, V> next;
+        private Node<K, V> prev;
+
+        public Node(K key, V value) {
+            super(key, value);
+        }
+    }
+
+    // Instead of a java.util.LinkedList, we use a doubly-linked list of nodes.
+    // This allows us to move the most-recently selected node from to the head of
+    // the list in O(1) time, instead of O(n) time.
+    private Node<K,V> head;
+
+    private final HashMap<K, Node<K,V>> entries;
 
     public RuleSet() {
         entries = new HashMap<>();
-        keys = new LinkedList<>();
     }
 
     public V get(Object key) {
         if (key != null) {
-            return entries.get(key);
+            Node<K,V> node = entries.get(key);
+            return node.getValue();
         }
         return null;
     }
@@ -49,8 +67,15 @@ public class RuleSet<K, V> implements Map<K, V>, Iterable<K> {
 
     @Override
     public V put(K key, V value) {
-        entries.put(key, value);
-        keys.offer(key);
+        Node<K,V> node = new Node<>(key, value);
+        if (head == null) {
+            head = node;
+        } else {
+            node.next = head;
+            head.prev = node;
+            head = node;
+        }
+        entries.put(key, node);
         return value;
     }
 
@@ -76,20 +101,74 @@ public class RuleSet<K, V> implements Map<K, V>, Iterable<K> {
 
     @Override
     public Collection<V> values() {
-        return entries.values();
+        Collection<V> values = new LinkedList<>();
+        for (Node<K,V> node = head; node != null; node = node.next) {
+            values.add(node.getValue());
+        }
+        return values;
     }
 
     @Override
     public Set<Entry<K, V>> entrySet() {
-        return entries.entrySet();
+        Set<Entry<K,V>> entrySet = new HashSet<>();
+        for (Node<K,V> node = head; node != null; node = node.next) {
+            entrySet.add(node);
+        }
+        return entrySet;
     }
 
-    public List<K> keys() {
-        return keys;
+    public Stream<Entry<K,V>> stream() {
+        return Stream.iterate(head, Objects::nonNull, node -> ((Node<K,V>)node).next);
+    }
+
+    private class KeyIterator implements Iterator<K> {
+        private Node<K, V> node;
+
+        public KeyIterator() {
+            node = head;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return node != null;
+        }
+
+        @Override
+        public K next() {
+            if (node == null) {
+                // per the Iterator contract
+                throw new NoSuchElementException();
+            }
+            Node<K, V> current = node;
+            node = node.next;
+            return current.getKey();
+        }
+
     }
 
     @Override
     public Iterator<K> iterator() {
-        return keys.iterator();
+        return new KeyIterator();
+    }
+
+    public V select(K key) {
+        // When a key is selected, move it to the head of the list.
+        // The list will be ordered from most-recently selected to least-recently selected.
+        // Side note: attempting to sort by most often selected resulted in worse performance.
+        final Node<K,V> selected = entries.get(key);
+        if (selected != head) {
+            if (selected.next != null) {
+                Node<K, V> next = selected.next;
+                next.prev = selected.prev;
+            }
+            if (selected.prev != null) {
+                Node<K, V> prev = selected.prev;
+                prev.next = selected.next;
+            }
+            head.prev = selected;
+            selected.next = head;
+            head = selected;
+        }
+        return selected.getValue();
     }
 }


### PR DESCRIPTION
Partially addresses issue #203 

Roughly measured, before these changes, a 394M G1GC log file took 111373 ms to parse. With these changes, the same log file took 80211 ms.  A 28% improvement. YMMV. 