### PR TITLE
Minor optimization for unified G1GC parsing

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/GCToolKit.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/GCToolKit.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import static java.lang.Class.forName;
@@ -305,7 +304,9 @@ public class GCToolKit {
         JavaVirtualMachine javaVirtualMachine = loadJavaVirtualMachine(logFile);
         try {
             List<Aggregator<? extends Aggregation>> filteredAggregators = filterAggregations(events);
+            long start = System.currentTimeMillis();
             javaVirtualMachine.analyze(filteredAggregators, jvmEventChannel, dataSourceChannel);
+            LOGGER.log(Level.FINE,() -> "Analysis completed in " + (System.currentTimeMillis() - start) + "ms");
         } catch(Throwable t) {
             LOGGER.log(Level.SEVERE, "Internal Error: Cannot invoke analyze method", t);
         }

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GCParseRule.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GCParseRule.java
@@ -44,4 +44,6 @@ public class GCParseRule {
     public String toString() {
         return this.name + " -> " + pattern.toString();
     }
+
+    public Pattern pattern() { return pattern; }
 }

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -199,7 +199,8 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
                 .findAny()
                 .ifPresentOrElse(
                         tuple -> {
-                            setForwardReference(gcid, line.substring(0, end));
+                            // Typically, "end" will be greater than zero, but not always.
+                            setForwardReference(gcid, end > 0 ? line.substring(0, end) : line);
                             applyRule(tuple.getKey(), tuple.getValue(), line);
                         },
                         () -> log(line)


### PR DESCRIPTION
Relative to issue #203 

Additional minor optimization for G1GC parsing. Since the rule pattern matches what comes after the GC id in the log line, use the end position of the GC id to substring the log line. Basically, don't try to match the pattern where we know the match will fail. 

The same optimization could not be used in the UnifiedGenerationalParser without having to re-engineer how that parser manages its forward reference. 