### PR TITLE
Move g1 heapRegionSize from class variable to member variable

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
@@ -32,7 +32,6 @@ import com.microsoft.gctoolkit.event.g1gc.G1YoungInitialMark;
 import com.microsoft.gctoolkit.parser.jvm.Decorators;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -44,9 +43,9 @@ class G1GCForwardReference extends ForwardReference {
     private static final Logger LOGGER = Logger.getLogger(G1GCForwardReference.class.getName());
 
     private int heapRegionSize = 0;
-    private static long minHeapSize;
-    private static long initialHeapSize;
-    private static long maxHeapSize;
+    private long minHeapSize;
+    private long initialHeapSize;
+    private long maxHeapSize;
     private DateTimeStamp concurrentCycleStartTime;
 
     void setHeapRegionSize(int sizeInMegaBytes) {
@@ -61,9 +60,8 @@ class G1GCForwardReference extends ForwardReference {
     private GarbageCollectionTypes gcType = null;
     private GarbageCollectionTypes concurrentPhase;
 
-    G1GCForwardReference(Decorators decorators, int gcID, int heapRegionSize) {
+    G1GCForwardReference(Decorators decorators, int gcID) {
         super(decorators, gcID);
-        this.heapRegionSize = heapRegionSize;
     }
 
     boolean isConcurrentCycle() {
@@ -71,27 +69,27 @@ class G1GCForwardReference extends ForwardReference {
     }
 
     //bag of stuff to maybe eliminate
-    static void setMinHeapSize(long minHeapSize) {
-        G1GCForwardReference.minHeapSize = minHeapSize;
+    void setMinHeapSize(long minHeapSize) {
+        this.minHeapSize = minHeapSize;
     }
 
-    static long getMinHeapSize() {
+    long getMinHeapSize() {
         return minHeapSize;
     }
 
-    static void setInitialHeapSize(long initialHeapSize) {
-        G1GCForwardReference.initialHeapSize = initialHeapSize;
+    void setInitialHeapSize(long initialHeapSize) {
+        this.initialHeapSize = initialHeapSize;
     }
 
-    static long getInitialHeapSize() {
+    long getInitialHeapSize() {
         return initialHeapSize;
     }
 
-    static void setMaxHeapSize(long maxHeapSize) {
-        G1GCForwardReference.maxHeapSize = maxHeapSize;
+    void setMaxHeapSize(long maxHeapSize) {
+        this.maxHeapSize = maxHeapSize;
     }
 
-    static long getMaxHeapSize() {
+    long getMaxHeapSize() {
         return maxHeapSize;
     }
 

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
@@ -43,17 +43,17 @@ class G1GCForwardReference extends ForwardReference {
 
     private static final Logger LOGGER = Logger.getLogger(G1GCForwardReference.class.getName());
 
-    private static int heapRegionSize = 0;
+    private int heapRegionSize = 0;
     private static long minHeapSize;
     private static long initialHeapSize;
     private static long maxHeapSize;
     private DateTimeStamp concurrentCycleStartTime;
 
-    static void setHeapRegionSize(int sizeInMegaBytes) {
+    void setHeapRegionSize(int sizeInMegaBytes) {
         heapRegionSize = sizeInMegaBytes;
     }
 
-    static int getHeapRegionSize() {
+    int getHeapRegionSize() {
         return heapRegionSize;
     }
 
@@ -61,8 +61,9 @@ class G1GCForwardReference extends ForwardReference {
     private GarbageCollectionTypes gcType = null;
     private GarbageCollectionTypes concurrentPhase;
 
-    G1GCForwardReference(Decorators decorators, int gcID) {
+    G1GCForwardReference(Decorators decorators, int gcID, int heapRegionSize) {
         super(decorators, gcID);
+        this.heapRegionSize = heapRegionSize;
     }
 
     boolean isConcurrentCycle() {

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -295,6 +295,7 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
     //[15.316s][debug][gc,heap      ] GC(0)   region size 1024K, 24 young (24576K), 0 survivors (0K)
     //ignore this logging for now
     private void youngRegionAllotment(GCLogTrace trace, String line) {
+        regionSize = trace.getIntegerGroup(1) / 1024;
         if (before) {
             forwardReference.setYoungOccupancyBeforeCollection(trace.getLongGroup(3));
             forwardReference.setSurvivorOccupancyBeforeCollection(trace.getLongGroup(5));

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -218,7 +218,11 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
 
     private void setForwardReference(int gcid, String line) {
         if (gcid != -1) {
-            forwardReference = collectionsUnderway.computeIfAbsent(gcid, k -> new G1GCForwardReference(new Decorators(line), gcid, regionSize));
+            forwardReference = collectionsUnderway.computeIfAbsent(gcid, k -> new G1GCForwardReference(new Decorators(line), gcid));
+            forwardReference.setHeapRegionSize(regionSize);
+            forwardReference.setMaxHeapSize(maxHeapSize);
+            forwardReference.setMinHeapSize(minHeapSize);
+            forwardReference.setInitialHeapSize(initialHeapSize);
         }
     }
 
@@ -280,13 +284,16 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
     //Minimum heap 8388608  Initial heap 268435456  Maximum heap 268435456
     //these values go back to the JavaVirtualMachine..
     public void heapSize(GCLogTrace trace, String line) {
-        G1GCForwardReference.setMinHeapSize(trace.getLongGroup(1));
-        G1GCForwardReference.setInitialHeapSize(trace.getLongGroup(2));
-        G1GCForwardReference.setMaxHeapSize(trace.getLongGroup(3));
+        this.minHeapSize = trace.getLongGroup(1);
+        this.initialHeapSize = trace.getLongGroup(2);
+        this.maxHeapSize = trace.getLongGroup(3);
     }
 
     //return to JVM
     private int regionSize = 0; //region size in Gigabytes
+    private long minHeapSize = 0;
+    private long initialHeapSize = 0;
+    private long maxHeapSize = 0;
 
     public void heapRegionSize(GCLogTrace trace, String line) {
         regionSize = trace.getIntegerGroup(1);
@@ -295,7 +302,7 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
     //[15.316s][debug][gc,heap      ] GC(0)   region size 1024K, 24 young (24576K), 0 survivors (0K)
     //ignore this logging for now
     private void youngRegionAllotment(GCLogTrace trace, String line) {
-        regionSize = trace.getIntegerGroup(1) / 1024;
+        forwardReference.setHeapRegionSize(trace.getIntegerGroup(1) / 1024);
         if (before) {
             forwardReference.setYoungOccupancyBeforeCollection(trace.getLongGroup(3));
             forwardReference.setSurvivorOccupancyBeforeCollection(trace.getLongGroup(5));

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -218,7 +218,7 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
 
     private void setForwardReference(int gcid, String line) {
         if (gcid != -1) {
-            forwardReference = collectionsUnderway.computeIfAbsent(gcid, k -> new G1GCForwardReference(new Decorators(line), gcid));
+            forwardReference = collectionsUnderway.computeIfAbsent(gcid, k -> new G1GCForwardReference(new Decorators(line), gcid, regionSize));
         }
     }
 
@@ -290,7 +290,6 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
 
     public void heapRegionSize(GCLogTrace trace, String line) {
         regionSize = trace.getIntegerGroup(1);
-        G1GCForwardReference.setHeapRegionSize(regionSize);
     }
 
     //[15.316s][debug][gc,heap      ] GC(0)   region size 1024K, 24 young (24576K), 0 survivors (0K)


### PR DESCRIPTION
Concurrent GCToolKit  instances with different  g1 region-size will affect each other  because of their static sharing of **G1GCForwardReference#heapRegionSize**. Consider moving it to a member variable.



