### PR TITLE
Catch IllegalArgumentException

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/GCToolKit.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/GCToolKit.java
@@ -115,8 +115,7 @@ public class GCToolKit {
                         LOG_DEBUG_MESSAGE(() -> "ServiceLoader provided: " + aggregation.getClass().getName());
                     });
         } catch (Throwable e) {
-            System.out.println(e.getMessage());
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw e;
         }
     }


### PR DESCRIPTION
IllegalArgumentException needs to be handled separately in order to provide more meaningful debugging information