### PR TITLE
Fix GenerationalHeapParser

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/CMSPatterns.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/CMSPatterns.java
@@ -244,8 +244,8 @@ public interface CMSPatterns extends SharedPatterns {
     // (concurrent mode failure): 62354K->8302K(64768K), 0.0931888 secs] 79477K->8302K(83392K), [CMS Perm : 10698K->10698K(21248K)], 0.0956950 secs] [Times: user=0.09 sys=0.00, real=0.09 secs]
     //(concurrent mode failure): 1044403K->1048509K(1048576K), 26.3929433 secs] 1478365K->1059706K(1520448K), 26.7743013 secs]
     // (concurrent mode failure): 62169K->8780K(64768K), 0.0909138 secs] 79462K->8780K(83392K), [CMS Perm : 10688K->10687K(21248K)], 0.0938215 secs]
-    GCParseRule CONCURRENT_MODE_FAILURE_DETAILS = new GCParseRule("CONCURRENT_MODE_FAILURE_DETAILS", "^\\(concurrent mode (?:failure|interrupted)\\): " + BEFORE_AFTER_CONFIGURED_PAUSE + "\\] " + BEFORE_AFTER_CONFIGURED + "(?:, " + PERM_RECORD + ")?, " + PAUSE_TIME + "\\]");
-    GCParseRule CONCURRENT_MODE_FAILURE_DETAILS_META = new GCParseRule("CONCURRENT_MODE_FAILURE_DETAILS_META", "^\\(concurrent mode (?:failure|interrupted)\\): " + BEFORE_AFTER_CONFIGURED_PAUSE + "\\] " + BEFORE_AFTER_CONFIGURED + "(?:, " + META_RECORD + ")?, " + PAUSE_TIME + "\\]");
+    GCParseRule CONCURRENT_MODE_FAILURE_DETAILS = new GCParseRule("CONCURRENT_MODE_FAILURE_DETAILS", "^\\s*\\(concurrent mode (?:failure|interrupted)\\): " + BEFORE_AFTER_CONFIGURED_PAUSE + "\\] " + BEFORE_AFTER_CONFIGURED + "(?:, " + PERM_RECORD + ")?, " + PAUSE_TIME + "\\]");
+    GCParseRule CONCURRENT_MODE_FAILURE_DETAILS_META = new GCParseRule("CONCURRENT_MODE_FAILURE_DETAILS_META", "^\\s*\\(concurrent mode (?:failure|interrupted)\\): " + BEFORE_AFTER_CONFIGURED_PAUSE + "\\] " + BEFORE_AFTER_CONFIGURED + "(?:, " + META_RECORD + ")?, " + PAUSE_TIME + "\\]");
 
     ////1.147: [Full GC (System) 1.147: [Tenured: 1827K->1889K(5312K), 0.0478658 secs] 2441K->1889K(7616K), [Perm : 10118K->10118K(21248K)], 0.0479395 secs]
     //1.149: [Full GC (System) 1.149: [CMS: 0K->1602K(62656K), 0.0761581 secs] 4659K->1602K(81280K), [CMS Perm : 10118K->10064K(21248K)], 0.0762653 secs] [Times: user=0.06 sys=0.01, real=0.08 secs]


### PR DESCRIPTION
Hello, i found that **GenerationalHeapParser** couldn't parse following CMS concurrent-mode-failure logs:

case1:
```
83.371: [CMS-concurrent-abortable-preclean-start]
83.751: [GC 83.751: [ParNew: 17024K->17024K(19136K), 0.0000236 secs]83.751: [CMS83.751: [CMS-concurrent-abortable-preclean: 0.026/0.380 secs] [Times: user=0.41 sys=0.04, real=0.38 secs] 
 (concurrent mode failure): 103355K->96073K(107776K), 0.5668205 secs] 120379K->96073K(126912K), [CMS Perm : 15591K->15585K(28412K)], 0.5669586 secs] [Times: user=0.57 sys=0.00, real=0.57 secs] 
```

case2:
```
2024-02-23T16:14:07.550+0800: 15897423.337: [GC (CMS Initial Mark) [1 CMS-initial-mark: 1398143K(1398144K)] 1957374K(1957376K), 0.4527312 secs] [Times: user=0.57 sys=0.00, real=0.45 secs]
2024-02-23T16:14:08.003+0800: 15897423.790: [CMS-concurrent-mark-start]
2024-02-23T16:14:08.172+0800: 15897423.959: [Full GC (Allocation Failure) 2024-02-23T16:14:08.172+0800: 15897423.959: [CMS2024-02-23T16:14:10.825+0800: 15897426.612: [CMS-concurrent-mark: 2.820/2.822 secs] [Times: user=2.57 sys=0.00, real=2.82 secs]
 (concurrent mode failure): 1398144K->1398143K(1398144K), 8.7753717 secs] 1957375K->1957374K(1957376K), [Metaspace: 63759K->63759K(1107968K)], 8.7755118 secs] [Times: user=8.17 sys=0.00, real=8.78 secs]
```

In these cases, there will be an extra  **SPACE**  before (concurrent mode failure), so  [CONCURRENT_MODE_FAILURE_DETAILS](https://github.com/microsoft/gctoolkit/blob/26e08f288a0400346b40610c2e5dc77c570dc5f3/parser/src/main/java/com/microsoft/gctoolkit/parser/CMSPatterns.java#L247)  and [CONCURRENT_MODE_FAILURE_DETAILS_META](https://github.com/microsoft/gctoolkit/blob/26e08f288a0400346b40610c2e5dc77c570dc5f3/parser/src/main/java/com/microsoft/gctoolkit/parser/CMSPatterns.java#L248) failed to recognize them.  Please take a look :)