### PR TITLE
update deps 28 mar 2024

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,20 +56,20 @@
 
     <properties>
         <revision>3.0.3-SNAPSHOT</revision>
-        <checkstyle.version>10.13.0</checkstyle.version>
-        <jreleaser.plugin.version>1.10.0</jreleaser.plugin.version>
+        <checkstyle.version>10.14.2</checkstyle.version>
+        <jreleaser.plugin.version>1.11.0</jreleaser.plugin.version>
         <junit5.version>5.10.2</junit5.version>
         <maven.antrun-plugin.version>3.1.0</maven.antrun-plugin.version>
         <maven.changes-plugin.version>2.12.1</maven.changes-plugin.version>
         <maven.checkstyle-plugin.version>3.3.1</maven.checkstyle-plugin.version>
         <maven.clean-plugin.version>3.3.2</maven.clean-plugin.version>
-        <maven.compiler-plugin.version>3.12.1</maven.compiler-plugin.version>
+        <maven.compiler-plugin.version>3.13.0</maven.compiler-plugin.version>
         <maven.compiler.release>11</maven.compiler.release>
         <maven.dependency-plugin.version>3.6.1</maven.dependency-plugin.version>
         <maven.deploy-plugin.version>3.1.1</maven.deploy-plugin.version>
         <maven.directory-maven-plugin.version>1.0</maven.directory-maven-plugin.version>
         <maven.enforcer-plugin.version>3.4.1</maven.enforcer-plugin.version>
-        <maven.exec-plugin.version>3.1.1</maven.exec-plugin.version>
+        <maven.exec-plugin.version>3.2.0</maven.exec-plugin.version>
         <maven.install-plugin.version>3.1.1</maven.install-plugin.version>
         <maven.jacoco-plugin.version>0.8.11</maven.jacoco-plugin.version>
         <maven.jar-plugin.version>3.3.0</maven.jar-plugin.version>
@@ -82,11 +82,12 @@
         <maven.resources-plugin.version>3.3.1</maven.resources-plugin.version>
         <maven.site-plugin.version>4.0.0-M13</maven.site-plugin.version>
         <maven.source-plugin.version>3.3.0</maven.source-plugin.version>
-        <maven.spotbugs-plugin.version>4.8.3.0</maven.spotbugs-plugin.version>
+        <maven.spotbugs-plugin.version>4.8.3.1</maven.spotbugs-plugin.version>
         <maven.surefire-plugin.version>3.2.5</maven.surefire-plugin.version>
         <maven.version>3.9.6</maven.version>
         <maven.versions-plugin.version>2.16.2</maven.versions-plugin.version>
         <mutability.detector.version>0.9.1</mutability.detector.version>
+        <!-- TODO Migrate to 7.0.0 -->
         <pmd.version>6.55.0</pmd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.github.repository>microsoft/gctoolkit</project.github.repository>
@@ -540,7 +541,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.2.2</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.7</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
- **Fill in region summaries for G1GCFull (#315)**
- **Update dependencies and ability to pass in compile version (#314)**
- **Fix YAML for ea workflow (#317)**
- **Correct CMSTenuredPoolParser (#320)**
- **Bump actions/cache from 3.3.2 to 3.3.3 (#321)**
- **Bump actions/cache from 3.3.3 to 4.0.0 (#322)**
- **Catch IllegalArgumentException (#325)**
- **Move g1 heapRegionSize from class variable to member variable (#324)**
- **Mark ConcurrentModeFailure and ConcurrentModeInterrupted as CMSPhase (#326)**
- **Latest dependencies (#329)**
- **Issue 316 (#331)**
- **Bump actions/setup-java from 4.0.0 to 4.1.0 (#334)**
- **Bump actions/cache from 4.0.0 to 4.0.1 (#335)**
- **Fix cms corner case (#332)**
- **Collapse of CMSParser into GenerationHeapParser (#337)**
- **Bump actions/checkout from 4.1.1 to 4.1.2 (#339)**
- **Bump actions/setup-java from 4.1.0 to 4.2.0 (#341)**
- **Bump actions/setup-java from 4.2.0 to 4.2.1 (#342)**
- **Bump actions/cache from 4.0.1 to 4.0.2 (#343)**
- **I need a title (#344)**
- **Update to latest versions**
