### PR TITLE
Estimate the start time by variance

### DIFF
--- a/IT/src/test/java/com/microsoft/gctoolkit/integration/CaptureJVMTerminationEventTest.java
+++ b/IT/src/test/java/com/microsoft/gctoolkit/integration/CaptureJVMTerminationEventTest.java
@@ -66,11 +66,11 @@ public class CaptureJVMTerminationEventTest {
             fail(e.getMessage());
         }
         Assertions.assertEquals( 2.193d, terminationAggregation.getStartTime().getTimeStamp(),0.001d, "Time of first event");
-        Assertions.assertEquals( 608800.088d, heapOccupancyAfterCollectionSummary.estimatedRuntime(),0.001d, "Runtime duration");
+        Assertions.assertEquals( 608797.895d, heapOccupancyAfterCollectionSummary.estimatedRuntime(),0.001d, "Runtime duration");
 
     }
    
-   @Aggregates({EventSource.CMS_PREUNIFIED,EventSource.CMS_UNIFIED,EventSource.G1GC,EventSource.GENERATIONAL,EventSource.JVM,EventSource.SHENANDOAH, EventSource.TENURED,EventSource.ZGC})
+   @Aggregates({EventSource.GENERATIONAL,EventSource.CMS_UNIFIED,EventSource.G1GC,EventSource.GENERATIONAL,EventSource.JVM,EventSource.SHENANDOAH, EventSource.TENURED,EventSource.ZGC})
     public static class JVMEventTerminationAggregator extends Aggregator<JVMTerminationEventAggregation> {
 
         public JVMEventTerminationAggregator(JVMTerminationEventAggregation aggregation) {

--- a/IT/src/test/java/com/microsoft/gctoolkit/integration/EndToEndIntegrationTest.java
+++ b/IT/src/test/java/com/microsoft/gctoolkit/integration/EndToEndIntegrationTest.java
@@ -86,7 +86,7 @@ public class EndToEndIntegrationTest {
         // Retrieves the Aggregation for PauseTimeSummary. This is a com.microsoft.gctoolkit.sample.aggregation.RuntimeAggregation.
         machine.getAggregation(PauseTimeSummary.class).ifPresent(pauseTimeSummary -> {
             Assertions.assertEquals( 208.922, pauseTimeSummary.getTotalPauseTime(), 0.001d, "Total Pause Time");
-            Assertions.assertEquals( 608800.087, pauseTimeSummary.estimatedRuntime(),0.001d, "Runtime duration");
+            Assertions.assertEquals( 608797.895, pauseTimeSummary.estimatedRuntime(),0.001d, "Runtime duration");
             Assertions.assertEquals( 34, (int)(pauseTimeSummary.getPercentPaused() * 1000d), "percent paused");
         });
 

--- a/IT/src/test/java/com/microsoft/gctoolkit/integration/TestSharedAggregators.java
+++ b/IT/src/test/java/com/microsoft/gctoolkit/integration/TestSharedAggregators.java
@@ -34,11 +34,11 @@ public class TestSharedAggregators {
         }
 
         jvm.getAggregation(OneRuntimeReport.class).ifPresentOrElse(
-                oneRuntimeReport -> Assertions.assertEquals(8.782d, oneRuntimeReport.getRuntimeDuration()),
+                oneRuntimeReport -> Assertions.assertEquals(8.772d, oneRuntimeReport.getRuntimeDuration()),
                 () -> Assertions.fail("1 report missing"));
 
         jvm.getAggregation(TwoRuntimeReport.class).ifPresentOrElse(
-                twoRuntimeReport -> Assertions.assertEquals(8.782d, twoRuntimeReport.getRuntimeDuration()),
+                twoRuntimeReport -> Assertions.assertEquals(8.772d, twoRuntimeReport.getRuntimeDuration()),
                 () -> Assertions.fail("2 report missing"));
     }
 }

--- a/IT/src/test/java/com/microsoft/gctoolkit/integration/core/PreunifiedJavaVirtualMachineConfigurationTest.java
+++ b/IT/src/test/java/com/microsoft/gctoolkit/integration/core/PreunifiedJavaVirtualMachineConfigurationTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class PreunifiedJavaVirtualMachineConfigurationTest {
 
     private String logFile = "preunified/g1gc/details/tenuring/180/g1gc.log";
-    private int[] times = { 0, 1028, 945481, 945481};
+    private int[] times = { 0, 1028, 945481, 944453};
 
     @Tag("modulePath")
     @Test

--- a/IT/src/test/java/com/microsoft/gctoolkit/integration/core/UnifiedJavaVirtualMachineConfigurationTest.java
+++ b/IT/src/test/java/com/microsoft/gctoolkit/integration/core/UnifiedJavaVirtualMachineConfigurationTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class UnifiedJavaVirtualMachineConfigurationTest {
 
     private String logFile = "rolling/jdk14/rollinglogs/long_restart.log";
-    private int[][] times = { { 0, 13, 262172, 262172}, { 259077, 259077, 262172, 3095}};
+    private int[][] times = { { 0, 13, 262172, 262159}, { 259077, 259077, 262172, 3992}};
 
     @Tag("modulePath")
     @Test

--- a/api/src/main/java/com/microsoft/gctoolkit/aggregator/Aggregator.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/aggregator/Aggregator.java
@@ -142,6 +142,8 @@ public abstract class Aggregator<A extends Aggregation> {
      * @param event an event to be processed
      */
     public void receive(JVMEvent event) {
+        aggregation().updateEventFrequency(event);
+
         if (event instanceof JVMTermination) {
             aggregation().timeOfTerminationEvent(((JVMTermination) event).getTimeOfTerminationEvent());
             aggregation().timeOfFirstEvent(((JVMTermination)event).getTimeOfFirstEvent());

--- a/api/src/main/java/com/microsoft/gctoolkit/online/statistics/NotEnoughSampleException.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/online/statistics/NotEnoughSampleException.java
@@ -1,0 +1,11 @@
+package com.microsoft.gctoolkit.online.statistics;
+
+public class NotEnoughSampleException extends ArithmeticException {
+    public NotEnoughSampleException() {
+        super();
+    }
+
+    public NotEnoughSampleException(String s) {
+        super(s);
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/online/statistics/OnlineMeanCalculator.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/online/statistics/OnlineMeanCalculator.java
@@ -1,0 +1,16 @@
+package com.microsoft.gctoolkit.online.statistics;
+
+public class OnlineMeanCalculator implements OnlineStatisticsCalculator {
+    private int numSamples = 0;
+    private double mean = 0.0;
+
+    public void update(double sampleValue) {
+        numSamples++;
+        mean += (sampleValue - mean) / numSamples;
+    }
+
+    @Override
+    public double getValue() {
+        return mean;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/online/statistics/OnlineStatisticsCalculator.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/online/statistics/OnlineStatisticsCalculator.java
@@ -1,0 +1,19 @@
+package com.microsoft.gctoolkit.online.statistics;
+
+public interface OnlineStatisticsCalculator {
+
+
+    /**
+     * Updates the statistics calculation with the given value.
+     * <p>
+     * For example, if the statistics calculation is a mean, this method would update the mean with the given value.
+     *
+     * @param sampleValue the value to be added to the statistics calculation
+     */
+    void update(double sampleValue);
+
+    /**
+     * @return the value of the statistics calculation
+     */
+    double getValue();
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/online/statistics/WelfordVarianceCalculator.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/online/statistics/WelfordVarianceCalculator.java
@@ -1,0 +1,27 @@
+package com.microsoft.gctoolkit.online.statistics;
+
+public class WelfordVarianceCalculator implements OnlineStatisticsCalculator {
+    private int numSamples = 0;
+    private double m2 = 0.0;
+    private final OnlineMeanCalculator onlineMeanCalculator = new OnlineMeanCalculator();
+
+    @Override
+    public void update(double sampleValue) {
+        double oldMean = onlineMeanCalculator.getValue();
+
+        onlineMeanCalculator.update(sampleValue);
+        numSamples++;
+
+        double newMean = onlineMeanCalculator.getValue();
+
+        m2 += (sampleValue - oldMean) * (sampleValue - newMean);
+    }
+
+    @Override
+    public double getValue() throws NotEnoughSampleException {
+        if (numSamples < 2) {
+            throw new NotEnoughSampleException("Variance requires at least 2 samples.");
+        }
+        return m2 / (numSamples - 1);
+    }
+}

--- a/api/src/test/java/com/microsoft/gctoolkit/online/statistics/WelfordVarianceCalculatorTest.java
+++ b/api/src/test/java/com/microsoft/gctoolkit/online/statistics/WelfordVarianceCalculatorTest.java
@@ -1,0 +1,34 @@
+package com.microsoft.gctoolkit.online.statistics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WelfordVarianceCalculatorTest {
+
+    @Test
+    void insufficientSamples() {
+        WelfordVarianceCalculator calculator = new WelfordVarianceCalculator();
+        calculator.update(1.23d);
+        assertThrows(NotEnoughSampleException.class, calculator::getValue);
+    }
+
+    @Test
+    void getVariance() {
+        WelfordVarianceCalculator calculator = new WelfordVarianceCalculator();
+        calculator.update(1421.23);
+        calculator.update(2897.34);
+        calculator.update(3907.45);
+        assertEquals(1563418.8054333332, calculator.getValue(), 0.0001d);
+    }
+
+    @Test
+    void getVarianceWithSmallDifference() {
+        WelfordVarianceCalculator calculator = new WelfordVarianceCalculator();
+        calculator.update(71899123.1273789);
+        calculator.update(71899123.1378323);
+        calculator.update(71899123.1478654);
+        assertEquals(0.00010493893, calculator.getValue(), 0.0001d);
+    }
+
+}


### PR DESCRIPTION
This PR is for fixing #257

Below is a summary of the changes made in this pull request:
- New `OnlineCalculator` classes - `WelfordVarianceCalculator` and `OnlineStatisticsCalculator`
  - This two classes allows to compute the mean and variance on-the-fly, without caching the dataset in memory
- Test cases for `OnlineCalculator` classes
- Update the way of computing estimated start time

Regarding the estimated start time, I used a slightly different approach than suggested in #257
- GC frequency is calculated as the time gap between two consecutive GC events.
  - For example, if event A happens at 2s and event B happens at 2.3s, the GC frequency is 2.3s - 2s = 0.3s.
- If `timeOfFirstEvent` does not have time stamp, the method will return `date stamp - SD of GC frequency`
- If `timeOfFirstEvent` has time stamp
 - it will first compute  `time stamp - SD of GC frequency`
   - if the value is greater than 0, then return value directly
   - otherwise return `timeOfFirstEvent`, since we cannot have negative time stamp

Please review the code and provide any comments or feedback you may have. I would also appreciate clarification on the specific points mentioned above!