### PR TITLE
Fix for gctoolkit #352 (Generational Heap Parser fails to recognize parallel gc lines)

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
@@ -1578,7 +1578,7 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
     //939.183: [GC [PSYoungGen: 523744K->844K(547584K)] 657668K->135357K(1035008K), 0.0157986 secs] [Times: user=0.30 sys=0.01, real=0.02 secs]
     public void psYoungGen(GCLogTrace trace, String line) {
         PSYoungGen collection = new PSYoungGen(getClock(), trace.gcCause(), trace.getDoubleGroup(trace.groupCount()));
-        collection.add(trace.getOccupancyBeforeAfterWithMemoryPoolSizeSummary(5), getTotalOccupancyBeforeAfterWithTotalHeapPoolSizeSummary(trace, 11));
+        collection.add(trace.getOccupancyBeforeAfterWithMemoryPoolSizeSummary(8), getTotalOccupancyBeforeAfterWithTotalHeapPoolSizeSummary(trace, 14));
         collection.add(extractCPUSummary(line));
         publish(collection);
     }
@@ -1714,7 +1714,7 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
     //GC-- indicated a promotion failed
     public void psFailure(GCLogTrace trace, String line) {
         PSYoungGen collection = new PSYoungGen(getClock(), GCCause.PROMOTION_FAILED, trace.getDoubleGroup(trace.groupCount()));
-        collection.add(trace.getOccupancyBeforeAfterWithMemoryPoolSizeSummary(5), getTotalOccupancyBeforeAfterWithTotalHeapPoolSizeSummary(trace, 11));
+        collection.add(trace.getOccupancyBeforeAfterWithMemoryPoolSizeSummary(8), getTotalOccupancyBeforeAfterWithTotalHeapPoolSizeSummary(trace, 14));
     }
 
     public void psYoungAdaptiveSizePolicy(GCLogTrace trace, String line) {

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/GenerationalHeapParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/GenerationalHeapParserTest.java
@@ -193,7 +193,25 @@ public class GenerationalHeapParserTest extends ParserTest {
         assertEquals(9.089,getParser().diary.getTimeOfFirstEvent().toSeconds());
     }
 
-
+    @Test
+    // jlittle-ptc: Added to validate changes in https://github.com/microsoft/gctoolkit/issues/352
+    // Fails without changes, passes with changes.
+    public void parallelYoungGenTest() {
+    	String[] lines = {
+    			"103.387: [GC [PSYoungGen: 138710K->17821K(154112K)] 138710K->17821K(506368K), 0.1040105 secs]",
+    			"135.734: [GC [PSYoungGen: 149917K->22007K(154112K)] 149917K->30709K(506368K), 0.2773358 secs]",
+    			"147.102: [GC [PSYoungGen: 154103K->22015K(154112K)] 162805K->57046K(506368K), 0.1371908 secs]",
+    			"156.646: [GC [PSYoungGen: 154111K->22001K(152320K)] 189142K->84340K(504576K), 0.1508722 secs]",
+    			"5989.323: [Full GC [PSYoungGen: 384K->0K(46208K)] [PSOldGen: 351520K->291209K(675840K)] 351904K->291209K(722048K) [PSPermGen: 46324K->46324K(94208K)], 5.6953760 secs]",
+    			"12023.260: [Full GC [PSYoungGen: 1463K->0K(172160K)] [PSOldGen: 674819K->546126K(917504K)] 676283K->546126K(1089664K) [PSPermGen: 75971K->75971K(126976K)], 12.4914242 secs]",
+    			"132380.027: [Full GC [PSYoungGen: 388637K->0K(581376K)] [PSOldGen: 1707204K->1099190K(1708032K)] 2095842K->1099190K(2289408K) [PSPermGen: 103975K->103975K(122880K)], 25.3055946 secs]"
+    	};
+    	
+        List<JVMEvent> jvmEvents = feedParser(lines);
+        assertEquals(7, jvmEvents.size());
+        assertEquals(103.387, getParser().diary.getTimeOfFirstEvent().toSeconds());    	
+    }
+      
     @Override
     protected Diarizer diarizer() {
         return new PreUnifiedDiarizer();


### PR DESCRIPTION
The bug was caused by mismatched indices in the regex that matches a Parallel collection.  The indices of two methods (YoungGen and Failure) in GenerationalHeapParser have been updated to correctly match the expected index so that the lines no longer generate a "not implemented" error in debug mode. 

I also reviewed the test suite to determine why this issue wasn't caught, and found that there was no test case that explicitly tested the parsing of Parallel GC lines, so I've added an additional test case for PSYoungGen that fails before the changes, and passes afterwards.  

I was unable to add a similar test case for Failure using the current strategy of parse and check for events as the failure line appears to be ignored. 

There is a chance that further fixes are required for less-frequently logged lines, but for any sample data I have available, the files now parse successfully. 