### PR TITLE
Support generational ZGC

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/OccupancySummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/OccupancySummary.java
@@ -26,4 +26,11 @@ public class OccupancySummary {
     public long getReclaimEnd() {
         return reclaimEnd;
     }
+
+    public OccupancySummary sum(OccupancySummary other) {
+        if (other == null) {
+            return this;
+        }
+        return new OccupancySummary(markEnd + other.markEnd, reclaimStart + other.reclaimStart, reclaimEnd + other.reclaimEnd);
+    }
 }

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ReclaimSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ReclaimSummary.java
@@ -20,4 +20,11 @@ public class ReclaimSummary {
         return reclaimEnd;
     }
 
+    public ReclaimSummary sum(ReclaimSummary other) {
+        if (other == null) {
+            return this;
+        }
+        return new ReclaimSummary(reclaimStart + other.reclaimStart, reclaimEnd + other.reclaimEnd);
+    }
+
 }

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCMemoryScope.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCMemoryScope.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.gctoolkit.parser;
 
 public enum ZGCMemoryScope {

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCMemoryScope.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCMemoryScope.java
@@ -1,0 +1,7 @@
+package com.microsoft.gctoolkit.parser;
+
+public enum ZGCMemoryScope {
+    ALL,
+    YOUNG_GENERATION,
+    OLD_GENERATION;
+}

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
@@ -59,6 +59,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         parseRules.put(PAUSE_PHASE, this::pausePhase);
         parseRules.put(CONCURRENT_PHASE, this::concurrentPhase);
         parseRules.put(LOAD, this::load);
+        parseRules.put(GENERATION_LOAD, this::load);
         parseRules.put(MMU, this::mmu);
         parseRules.put(MARK_SUMMARY, this::markSummary);
         parseRules.put(RELOCATION_SUMMARY, this::relocationSummary);
@@ -66,6 +67,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         parseRules.put(METASPACE, this::metaspace);
         parseRules.put(REFERENCE_PROCESSING, this::referenceProcessing);
         parseRules.put(CAPACITY, this::capacity);
+        parseRules.put(GENERATIONAL_MEMORY_STATISTICS, this::memoryStatistics);
         parseRules.put(MEMORY_TABLE_ENTRY_SIZE, this::sizeEntry);
         parseRules.put(MEMORY_TABLE_ENTRY_OCCUPANCY, this::occupancyEntry);
         parseRules.put(MEMORY_TABLE_ENTRY_RECLAIMED, this::reclaimed);
@@ -144,7 +146,8 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         } else if ("Mark Free".equals(trace.getGroup(1))) {
             forwardReference.setConcurrentMarkFreeDuration(trace.getDuration());
             forwardReference.setConcurrentMarkFreeStart(startTime);
-        } else if ("Process Non-Strong References".equals(trace.getGroup(1))) {
+        } else if ("Process Non-Strong References".equals(trace.getGroup(1))
+                || "Process Non-Strong".equals(trace.getGroup(1))) {
             forwardReference.setConcurrentProcessNonStrongReferencesDuration(trace.getDuration());
             forwardReference.setConcurrentProcessNonStringReferencesStart(startTime);
         } else if ("Reset Relocation Set".equals(trace.getGroup(1))) {
@@ -214,6 +217,19 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         relocateEnd[index] = trace.toKBytes(11);
     }
 
+    private void memoryStatistics(GCLogTrace trace, String s) {
+        switch (trace.getGroup(1)) {
+            case "Young Generation":
+                forwardReference.setMemoryScope(1);
+                break;
+            case "Old Generation":
+                forwardReference.setMemoryScope(2);
+                break;
+            default:
+                forwardReference.setMemoryScope(0);
+        }
+    }
+
     private void sizeEntry(GCLogTrace trace, String s) {
         switch (trace.getGroup(1)) {
             case "Capacity":
@@ -223,10 +239,11 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
                 captureAtIndex(trace, 1);
                 break;
             case "Used":
-                forwardReference.setMarkStart(new ZGCMemoryPoolSummary(markStart[0], markStart[1], trace.toKBytes(2)));
-                forwardReference.setMarkEnd(new ZGCMemoryPoolSummary(markEnd[0], markEnd[1], trace.toKBytes(5)));
-                forwardReference.setRelocateStart(new ZGCMemoryPoolSummary(relocateStart[0], relocateStart[1], trace.toKBytes(8)));
-                forwardReference.setRelocateEnd(new ZGCMemoryPoolSummary(relocateEnd[0], relocateEnd[1], trace.toKBytes(11)));
+                captureAtIndex(trace, 2);
+                forwardReference.setMarkStart(new ZGCMemoryPoolSummary(markStart[0], markStart[1], markStart[2]));
+                forwardReference.setMarkEnd(new ZGCMemoryPoolSummary(markEnd[0], markEnd[1], markEnd[2]));
+                forwardReference.setRelocateStart(new ZGCMemoryPoolSummary(relocateStart[0], relocateStart[1], relocateStart[2]));
+                forwardReference.setRelocateEnd(new ZGCMemoryPoolSummary(relocateEnd[0], relocateEnd[1], relocateEnd[2]));
                 break;
             default:
                 LOGGER.warning(trace.getGroup(1) + "not recognized, Heap Occupancy/size is is ignored. Please report this with the GC log");
@@ -323,6 +340,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         private ReclaimSummary reclaimed;
         private ReclaimSummary memorySummary;
         private ZGCMetaspaceSummary metaspace;
+        private int memoryScope; // 0: default all heap; 1: young generation; 2: old generation
 
         //Load
         private double[] load = new double[3];
@@ -363,107 +381,150 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         }
 
         public void setPauseMarkStart(DateTimeStamp pauseMarkStart) {
+            if (this.pauseMarkStart != null) {
+                return;
+            }
             this.pauseMarkStart = pauseMarkStart;
         }
 
         public void setPauseMarkStartDuration(double pauseMarkStartDuration) {
-            this.pauseMarkStartDuration = pauseMarkStartDuration;
+            this.pauseMarkStartDuration += pauseMarkStartDuration;
         }
 
         public void setPauseMarkEndStart(DateTimeStamp pauseMarkEndStart) {
+            if (this.pauseMarkEndStart != null) {
+                return;
+            }
             this.pauseMarkEndStart = pauseMarkEndStart;
         }
 
         public void setPauseMarkEndDuration(double pauseMarkEndDuration) {
-            this.pauseMarkEndDuration = pauseMarkEndDuration;
+            this.pauseMarkEndDuration += pauseMarkEndDuration;
         }
 
         public void setPauseRelocateStart(DateTimeStamp pauseRelocateStart) {
+            if (this.pauseRelocateStart != null) {
+                return;
+            }
             this.pauseRelocateStart = pauseRelocateStart;
         }
 
         public void setPauseRelocateStartDuration(double pauseRelocateStartDuration) {
-            this.pauseRelocateStartDuration = pauseRelocateStartDuration;
+            this.pauseRelocateStartDuration += pauseRelocateStartDuration;
         }
 
         public void setConcurrentMarkStart(DateTimeStamp concurrentMarkStart) {
+            if (this.concurrentMarkStart != null) {
+                return;
+            }
             this.concurrentMarkStart = concurrentMarkStart;
         }
 
         public void setConcurrentMarkDuration(double concurrentMarkDuration) {
-            this.concurrentMarkDuration = concurrentMarkDuration;
+            this.concurrentMarkDuration += concurrentMarkDuration;
         }
 
         public void setConcurrentMarkFreeStart(DateTimeStamp concurrentMarkFreeStart) {
+            if (this.concurrentMarkFreeStart != null) {
+                return;
+            }
             this.concurrentMarkFreeStart = concurrentMarkFreeStart;
         }
         public void setConcurrentMarkFreeDuration(double concurrentMarkFreeDuration) {
-            this.concurrentMarkFreeDuration = concurrentMarkFreeDuration;
+            this.concurrentMarkFreeDuration += concurrentMarkFreeDuration;
         }
 
         public void setConcurrentProcessNonStringReferencesStart(DateTimeStamp concurrentProcessNonStringReferencesStart) {
+            if (this.concurrentProcessNonStringReferencesStart != null) {
+                return;
+            }
             this.concurrentProcessNonStringReferencesStart = concurrentProcessNonStringReferencesStart;
         }
 
         public void setConcurrentProcessNonStrongReferencesDuration(double concurrentProcessNonStrongReferencesDuration) {
-            this.concurrentProcessNonStrongReferencesDuration = concurrentProcessNonStrongReferencesDuration;
+            this.concurrentProcessNonStrongReferencesDuration += concurrentProcessNonStrongReferencesDuration;
         }
 
         public void setConcurrentResetRelocationSetStart(DateTimeStamp concurrentResetRelocationSetStart) {
+            if (this.concurrentResetRelocationSetStart != null) {
+                return;
+            }
             this.concurrentResetRelocationSetStart = concurrentResetRelocationSetStart;
         }
 
         public void setConcurrentResetRelocationSetDuration(double concurrentResetRelocationSetDuration) {
-            this.concurrentResetRelocationSetDuration = concurrentResetRelocationSetDuration;
+            this.concurrentResetRelocationSetDuration += concurrentResetRelocationSetDuration;
         }
 
         public void setConcurrentSelectRelocationSetStart(DateTimeStamp concurrentSelectRelocationSetStart) {
+            if (this.concurrentSelectRelocationSetStart != null) {
+                return;
+            }
             this.concurrentSelectRelocationSetStart = concurrentSelectRelocationSetStart;
         }
 
         public void setConcurrentSelectRelocationSetDuration(double concurrentSelectRelocationSetDuration) {
-            this.concurrentSelectRelocationSetDuration = concurrentSelectRelocationSetDuration;
+            this.concurrentSelectRelocationSetDuration += concurrentSelectRelocationSetDuration;
         }
 
         public void setConcurrentSelectRelocateStart(DateTimeStamp concurrentSelectRelocateStart) {
+            if (this.concurrentSelectRelocateStart != null) {
+                return;
+            }
             this.concurrentSelectRelocateStart = concurrentSelectRelocateStart;
         }
 
         public void setConcurrentSelectRelocateDuration(double concurrentSelectRelocateDuration) {
-            this.concurrentSelectRelocateDuration = concurrentSelectRelocateDuration;
+            this.concurrentSelectRelocateDuration += concurrentSelectRelocateDuration;
+        }
+
+        public void setMemoryScope(int scope) {
+            this.memoryScope = scope;
         }
 
         //Memory
         public void setMarkStart(ZGCMemoryPoolSummary summary) {
+            if (memoryScope != 0) {
+                return;
+            }
             this.markStart = summary;
         }
 
         public void setMarkEnd(ZGCMemoryPoolSummary summary) {
+            if (memoryScope != 0) {
+                return;
+            }
             this.markEnd = summary;
         }
 
         public void setRelocateStart(ZGCMemoryPoolSummary summary) {
+            if (memoryScope != 0) {
+                return;
+            }
             this.relocatedStart = summary;
         }
 
         public void setRelocateEnd(ZGCMemoryPoolSummary summary) {
+            if (memoryScope != 0) {
+                return;
+            }
             this.relocateEnd = summary;
         }
 
         public void setMarkedLive(OccupancySummary summary) {
-            markedLive = summary;
+            this.markedLive = summary.sum(this.markedLive);
         }
 
         public void setAllocated(OccupancySummary summary) {
-            this.allocated = summary;
+            this.allocated = summary.sum(this.allocated);
         }
 
         public void setGarbage(OccupancySummary summary) {
-            this.garbage = summary;
+            this.garbage = summary.sum(this.garbage);
         }
 
         public void setReclaimed(ReclaimSummary summary) {
-            reclaimed = summary;
+            this.reclaimed = summary.sum(this.reclaimed);
         }
 
         public void setMemorySummary(ReclaimSummary summary) {

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
@@ -220,13 +220,13 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     private void memoryStatistics(GCLogTrace trace, String s) {
         switch (trace.getGroup(1)) {
             case "Young Generation":
-                forwardReference.setMemoryScope(1);
+                forwardReference.setMemoryScope(ZGCMemoryScope.YOUNG_GENERATION);
                 break;
             case "Old Generation":
-                forwardReference.setMemoryScope(2);
+                forwardReference.setMemoryScope(ZGCMemoryScope.OLD_GENERATION);
                 break;
             default:
-                forwardReference.setMemoryScope(0);
+                forwardReference.setMemoryScope(ZGCMemoryScope.ALL);
         }
     }
 
@@ -340,7 +340,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         private ReclaimSummary reclaimed;
         private ReclaimSummary memorySummary;
         private ZGCMetaspaceSummary metaspace;
-        private int memoryScope; // 0: default all heap; 1: young generation; 2: old generation
+        private ZGCMemoryScope memoryScope = ZGCMemoryScope.ALL;
 
         //Load
         private double[] load = new double[3];
@@ -478,34 +478,34 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
             this.concurrentSelectRelocateDuration += concurrentSelectRelocateDuration;
         }
 
-        public void setMemoryScope(int scope) {
+        public void setMemoryScope(ZGCMemoryScope scope) {
             this.memoryScope = scope;
         }
 
         //Memory
         public void setMarkStart(ZGCMemoryPoolSummary summary) {
-            if (memoryScope != 0) {
+            if (memoryScope != ZGCMemoryScope.ALL) {
                 return;
             }
             this.markStart = summary;
         }
 
         public void setMarkEnd(ZGCMemoryPoolSummary summary) {
-            if (memoryScope != 0) {
+            if (memoryScope != ZGCMemoryScope.ALL) {
                 return;
             }
             this.markEnd = summary;
         }
 
         public void setRelocateStart(ZGCMemoryPoolSummary summary) {
-            if (memoryScope != 0) {
+            if (memoryScope != ZGCMemoryScope.ALL) {
                 return;
             }
             this.relocatedStart = summary;
         }
 
         public void setRelocateEnd(ZGCMemoryPoolSummary summary) {
-            if (memoryScope != 0) {
+            if (memoryScope != ZGCMemoryScope.ALL) {
                 return;
             }
             this.relocateEnd = summary;

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
@@ -9,25 +9,30 @@ public interface ZGCPatterns extends UnifiedPatterns {
 
     String MEMORY_PERCENT = GenericTokens.INT + GenericTokens.UNITS + "\\s*\\(" + GenericTokens.INT + "%\\)";
 
+    String LOAD_PERCENT = GenericTokens.REAL_VALUE + " \\(" + GenericTokens.INTEGER + "%\\)";
+
     GCParseRule ZGC_TAG = new GCParseRule("ZGC Tag", "Initializing The Z Garbage Collector$");
 
     //[3.558s][info ][gc,start       ] GC(3) Garbage Collection (Warmup)
-    GCParseRule CYCLE_START = new GCParseRule("CYCLE_START", "GC\\(" + GenericTokens.INT + "\\) Garbage Collection " + GenericTokens.GC_CAUSE + "$");
+    GCParseRule CYCLE_START = new GCParseRule("CYCLE_START", "GC\\(" + GenericTokens.INT + "\\) (?:Garbage|Major|Minor) Collection " + GenericTokens.GC_CAUSE + "$");
 
     //[3.559s][info ][gc,phases      ] GC(3) Pause Mark Start 0.460ms
     //[3.574s][info ][gc,phases      ] GC(3) Pause Mark End 0.830ms
     //[3.583s][info ][gc,phases      ] GC(3) Pause Relocate Start 0.794ms
-    GCParseRule PAUSE_PHASE = new GCParseRule("Pause Phase", "Pause (Mark Start|Mark End|Relocate Start) " + GenericTokens.PAUSE_TIME);
+    GCParseRule PAUSE_PHASE = new GCParseRule("Pause Phase", "Pause (Mark Start|Mark End|Relocate Start)(?: \\((Major|Minor)\\))? " + GenericTokens.PAUSE_TIME);
 
     //[3.573s][info ][gc,phases      ] GC(3) Concurrent Mark 14.621ms
     //[3.578s][info ][gc,phases      ] GC(3) Concurrent Process Non-Strong References 3.654ms
     //[3.578s][info ][gc,phases      ] GC(3) Concurrent Reset Relocation Set 0.194ms
     //[3.582s][info ][gc,phases      ] GC(3) Concurrent Select Relocation Set 3.193ms
     //[3.596s][info ][gc,phases      ] GC(3) Concurrent Relocate 12.962ms
-    GCParseRule CONCURRENT_PHASE = new GCParseRule("Concurrent Phase","Concurrent (Mark|Mark Free|Process Non-Strong References|Reset Relocation Set|Select Relocation Set|Relocate) " + GenericTokens.PAUSE_TIME);
+    GCParseRule CONCURRENT_PHASE = new GCParseRule("Concurrent Phase","Concurrent (Mark|Mark Free|Process Non-Strong References|Process Non-Strong|Reset Relocation Set|Select Relocation Set|Relocate) " + GenericTokens.PAUSE_TIME);
 
     //[3.596s][info ][gc,load        ] GC(3) Load: 4.28/3.95/3.22
     GCParseRule LOAD = new GCParseRule("Load","Load: " + GenericTokens.REAL_VALUE + "/" + GenericTokens.REAL_VALUE + "/" + GenericTokens.REAL_VALUE);
+
+    // [4.220s][info][gc,load     ] GC(0) O: Load: 9.07 (19%) / 9.48 (20%) / 10.07 (21%)
+    GCParseRule GENERATION_LOAD = new GCParseRule("Load","Load: " + LOAD_PERCENT + " / " + LOAD_PERCENT + " / " + LOAD_PERCENT);
 
     //[3.596s][info ][gc,mmu         ] GC(3) MMU: 2ms/32.7%, 5ms/60.8%, 10ms/80.4%, 20ms/85.4%, 50ms/90.8%, 100ms/95.4%
     GCParseRule MMU = new GCParseRule("MMU","MMU: 2ms/" + GenericTokens.PERCENTAGE + ", 5ms/" + GenericTokens.PERCENTAGE + ", 10ms/" + GenericTokens.PERCENTAGE + ", 20ms/" + GenericTokens.PERCENTAGE + ", 50ms/" + GenericTokens.PERCENTAGE + ", 100ms/" + GenericTokens.PERCENTAGE);
@@ -75,7 +80,7 @@ public interface ZGCPatterns extends UnifiedPatterns {
     GCParseRule MEMORY_TABLE_ENTRY_RECLAIMED = new GCParseRule("Memory table entry reclaimed", "Reclaimed:\\s*-\\s*-\\s*" + MEMORY_PERCENT + "\\s*" + MEMORY_PERCENT);
 
     //[3.596s][info ][gc             ] GC(3) Garbage Collection (Warmup) 894M(22%)->186M(5%)
-    GCParseRule MEMORY_SUMMARY = new GCParseRule("Memory Summary","Garbage Collection " + GenericTokens.GC_CAUSE + MEMORY_PERCENT + "->" + MEMORY_PERCENT);
+    GCParseRule MEMORY_SUMMARY = new GCParseRule("Memory Summary","(?:Garbage|Major|Minor) Collection " + GenericTokens.GC_CAUSE + MEMORY_PERCENT + "->" + MEMORY_PERCENT);
 
     /*
     todo: capture and report on these log entries
@@ -99,4 +104,11 @@ public interface ZGCPatterns extends UnifiedPatterns {
         [0.010s][info ][gc,init] Uncommit: Enabled, Delay: 300s
      */
 
+    /*
+        [4.179s][info][gc,heap     ] GC(0) Y: Heap Statistics:
+        [4.179s][info][gc,heap     ] GC(0) Y: Young Generation Statistics:
+        [4.220s][info][gc,heap     ] GC(0) O: Heap Statistics:
+        [4.220s][info][gc,heap     ] GC(0) O: Old Generation Statistics:
+     */
+    GCParseRule GENERATIONAL_MEMORY_STATISTICS = new GCParseRule("Generational Heap Statistics","(Young Generation|Old Generation|Heap) Statistics:");
 }

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
@@ -131,6 +131,164 @@ public class ZGCParserTest extends ParserTest {
         }
     }
 
+    @Test
+    public void infoLevelGenerationalZGCCycle() {
+
+        String[] eventLogEntries = {
+                "[4.120s][info][gc          ] GC(0) Major Collection (Metadata GC Threshold)" ,
+                "[4.120s][info][gc,task     ] GC(0) Using 1 Workers for Young Generation" ,
+                "[4.120s][info][gc,task     ] GC(0) Using 1 Workers for Old Generation" ,
+                "[4.120s][info][gc,phases   ] GC(0) Y: Young Generation" ,
+                "[4.120s][info][gc,phases   ] GC(0) Y: Pause Mark Start (Major) 0.066ms" ,
+                "[4.155s][info][gc,phases   ] GC(0) Y: Concurrent Mark 34.619ms" ,
+                "[4.155s][info][gc,phases   ] GC(0) Y: Pause Mark End 0.016ms" ,
+                "[4.155s][info][gc,phases   ] GC(0) Y: Concurrent Mark Free 0.001ms" ,
+                "[4.155s][info][gc,phases   ] GC(0) Y: Concurrent Reset Relocation Set 0.001ms" ,
+                "[4.163s][info][gc,reloc    ] GC(0) Y: Using tenuring threshold: 1 (Computed)" ,
+                "[4.165s][info][gc,phases   ] GC(0) Y: Concurrent Select Relocation Set 10.037ms" ,
+                "[4.165s][info][gc,phases   ] GC(0) Y: Pause Relocate Start 0.014ms" ,
+                "[4.179s][info][gc,phases   ] GC(0) Y: Concurrent Relocate 13.784ms" ,
+                "[4.179s][info][gc,alloc    ] GC(0) Y:                         Mark Start        Mark End      Relocate Start    Relocate End" ,
+                "[4.179s][info][gc,alloc    ] GC(0) Y: Allocation Stalls:          0                0                0                0" ,
+                "[4.179s][info][gc,load     ] GC(0) Y: Load: 9.07 (19%) / 9.48 (20%) / 10.07 (21%)" ,
+                "[4.179s][info][gc,mmu      ] GC(0) Y: MMU: 2ms/96.7%, 5ms/98.7%, 10ms/99.3%, 20ms/99.7%, 50ms/99.8%, 100ms/99.9%" ,
+                "[4.179s][info][gc,marking  ] GC(0) Y: Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s)" ,
+                "[4.179s][info][gc,marking  ] GC(0) Y: Mark Stack Usage: 32M" ,
+                "[4.179s][info][gc,nmethod  ] GC(0) Y: NMethods: 2191 registered, 0 unregistered" ,
+                "[4.179s][info][gc,metaspace] GC(0) Y: Metaspace: 21M used, 21M committed, 1088M reserved" ,
+                "[4.179s][info][gc,reloc    ] GC(0) Y:                        Candidates     Selected     In-Place         Size        Empty    Relocated" ,
+                "[4.179s][info][gc,reloc    ] GC(0) Y: Small Pages:                   49           40            0          98M           0M           6M" ,
+                "[4.179s][info][gc,reloc    ] GC(0) Y: Medium Pages:                   1            0            0          32M           0M           0M" ,
+                "[4.179s][info][gc,reloc    ] GC(0) Y: Large Pages:                    0            0            0           0M           0M           0M" ,
+                "[4.179s][info][gc,reloc    ] GC(0) Y: Forwarding Usage: 2M" ,
+                "[4.179s][info][gc,reloc    ] GC(0) Y: Age Table:" ,
+                "[4.179s][info][gc,reloc    ] GC(0) Y:                    Live             Garbage             Small              Medium             Large" ,
+                "[4.179s][info][gc,reloc    ] GC(0) Y: Eden              16M (1%)          113M (4%)          49 / 40             1 / 0              0 / 0" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y: Min Capacity: 3000M(100%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y: Max Capacity: 3000M(100%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y: Soft Max Capacity: 3000M(100%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y: Heap Statistics:" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y:                Mark Start          Mark End        Relocate Start      Relocate End           High               Low" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y:  Capacity:     3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y:      Free:     2870M (96%)        2866M (96%)        2866M (96%)        2928M (98%)        2934M (98%)        2862M (95%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y:      Used:      130M (4%)          134M (4%)          134M (4%)           72M (2%)          138M (5%)           66M (2%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y: Young Generation Statistics:" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y:                Mark Start          Mark End        Relocate Start      Relocate End" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y:      Used:      130M (4%)          134M (4%)          134M (4%)           72M (2%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y:      Live:         -                16M (1%)           16M (1%)           16M (1%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y:   Garbage:         -               113M (4%)          113M (4%)           32M (1%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y: Allocated:         -                 4M (0%)            4M (0%)           23M (1%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y: Reclaimed:         -                  -                 0M (0%)           81M (3%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y:  Promoted:         -                  -                 0M (0%)            0M (0%)" ,
+                "[4.179s][info][gc,heap     ] GC(0) Y: Compacted:         -                  -                  -                 8M (0%)" ,
+                "[4.179s][info][gc,phases   ] GC(0) Y: Young Generation 130M(4%)->72M(2%) 0.059s" ,
+                "[4.179s][info][gc,phases   ] GC(0) O: Old Generation" ,
+                "[4.182s][info][gc,phases   ] GC(0) O: Concurrent Mark 2.407ms" ,
+                "[4.182s][info][gc,phases   ] GC(0) O: Pause Mark End 0.014ms" ,
+                "[4.182s][info][gc,phases   ] GC(0) O: Concurrent Mark Free 0.009ms" ,
+                "[4.189s][info][gc,phases   ] GC(0) O: Concurrent Process Non-Strong 7.001ms" ,
+                "[4.189s][info][gc,phases   ] GC(0) O: Concurrent Reset Relocation Set 0.001ms" ,
+                "[4.193s][info][gc,phases   ] GC(0) O: Concurrent Select Relocation Set 4.466ms" ,
+                "[4.193s][info][gc,task     ] GC(0) O: Using 1 Workers for Old Generation" ,
+                "[4.218s][info][gc,task     ] GC(0) O: Using 1 Workers for Old Generation" ,
+                "[4.218s][info][gc,phases   ] GC(0) O: Concurrent Remap Roots 24.683ms" ,
+                "[4.220s][info][gc,phases   ] GC(0) O: Pause Relocate Start 0.013ms" ,
+                "[4.220s][info][gc,phases   ] GC(0) O: Concurrent Relocate 0.043ms" ,
+                "[4.220s][info][gc,alloc    ] GC(0) O:                         Mark Start        Mark End      Relocate Start    Relocate End" ,
+                "[4.220s][info][gc,alloc    ] GC(0) O: Allocation Stalls:          0                0                0                0" ,
+                "[4.220s][info][gc,load     ] GC(0) O: Load: 9.07 (19%) / 9.48 (20%) / 10.07 (21%)" ,
+                "[4.220s][info][gc,mmu      ] GC(0) O: MMU: 2ms/96.7%, 5ms/98.7%, 10ms/99.3%, 20ms/99.7%, 50ms/99.8%, 100ms/99.9%" ,
+                "[4.220s][info][gc,marking  ] GC(0) O: Mark: 1 stripe(s), 1 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s)" ,
+                "[4.220s][info][gc,marking  ] GC(0) O: Mark Stack Usage: 0M" ,
+                "[4.220s][info][gc,nmethod  ] GC(0) O: NMethods: 1891 registered, 334 unregistered" ,
+                "[4.220s][info][gc,metaspace] GC(0) O: Metaspace: 22M used, 22M committed, 1088M reserved" ,
+                "[4.220s][info][gc,ref      ] GC(0) O:                       Encountered   Discovered     Enqueued" ,
+                "[4.220s][info][gc,ref      ] GC(0) O: Soft References:             3666            0            0" ,
+                "[4.220s][info][gc,ref      ] GC(0) O: Weak References:             1214            0            0" ,
+                "[4.220s][info][gc,ref      ] GC(0) O: Final References:              19            0            0" ,
+                "[4.220s][info][gc,ref      ] GC(0) O: Phantom References:           767            0            0" ,
+                "[4.220s][info][gc,heap     ] GC(0) O: Min Capacity: 3000M(100%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O: Max Capacity: 3000M(100%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O: Soft Max Capacity: 3000M(100%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O: Heap Statistics:" ,
+                "[4.220s][info][gc,heap     ] GC(0) O:                Mark Start          Mark End        Relocate Start      Relocate End           High               Low" ,
+                "[4.220s][info][gc,heap     ] GC(0) O:  Capacity:     3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O:      Free:     2870M (96%)        2928M (98%)        2926M (98%)        2926M (98%)        2934M (98%)        2862M (95%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O:      Used:      130M (4%)           72M (2%)           74M (2%)           74M (2%)          138M (5%)           66M (2%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O: Old Generation Statistics:" ,
+                "[4.220s][info][gc,heap     ] GC(0) O:                Mark Start          Mark End        Relocate Start      Relocate End" ,
+                "[4.220s][info][gc,heap     ] GC(0) O:      Used:        0M (0%)            0M (0%)            0M (0%)            0M (0%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O:      Live:         -                 0M (0%)            0M (0%)            0M (0%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O:   Garbage:         -                 0M (0%)            0M (0%)            0M (0%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O: Allocated:         -                 0M (0%)            0M (0%)            0M (0%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O: Reclaimed:         -                  -                 0M (0%)            0M (0%)" ,
+                "[4.220s][info][gc,heap     ] GC(0) O: Compacted:         -                  -                  -                 0M (0%)" ,
+                "[4.220s][info][gc,phases   ] GC(0) O: Old Generation 72M(2%)->74M(2%) 0.041s" ,
+                "[4.220s][info][gc          ] GC(0) Major Collection (Metadata GC Threshold) 130M(4%)->74M(2%) 0.100s"
+        };
+
+        List<JVMEvent> singleCycle = feedParser(eventLogEntries);
+        try {
+            assertEquals(1, singleCycle.size());
+            ZGCCycle zgc = (ZGCCycle) singleCycle.get(0);
+
+            assertEquals(zgc.getGcId(), 0L);
+
+            assertEquals(0.1d, zgc.getDuration(),0.001d);
+            assertEquals(toInt(4.120d, 1000), toInt(zgc.getDateTimeStamp().getTimeStamp(), 1000));
+            assertEquals("Metadata GC Threshold", zgc.getGCCause().getLabel());
+            // Durations
+            assertEquals(4.120d, zgc.getPauseMarkStartTimeStamp().getTimeStamp(),  0.001d);
+            assertEquals(4.120d, zgc.getConcurrentMarkTimeStamp().getTimeStamp(), 0.001d);
+            assertEquals(4.155d, zgc.getConcurrentMarkFreeTimeStamp().getTimeStamp(), 0.001d);
+            assertEquals(4.155d, zgc.getPauseMarkEndTimeStamp().getTimeStamp(), 0.001d);
+            assertEquals(4.182d, zgc.getConcurrentProcessNonStrongReferencesTimeStamp().getTimeStamp(), 0.002d);
+            assertEquals(4.155d, zgc.getConcurrentResetRelocationSetTimeStamp().getTimeStamp(), 0.001d);
+            assertEquals(4.155d, zgc.getConcurrentSelectRelocationSetTimeStamp().getTimeStamp(), 0.001d);
+            assertEquals(4.165d, zgc.getPauseRelocateStartTimeStamp().getTimeStamp(), 0.001d);
+            assertEquals(4.165d, zgc.getConcurrentRelocateTimeStamp().getTimeStamp(), 0.001d);
+
+            assertEquals(0.066d, zgc.getPauseMarkStartDuration(),  0.001);
+            assertEquals(37.026d, zgc.getConcurrentMarkDuration(),  0.001);
+            assertEquals(0.010d, zgc.getConcurrentMarkFreeDuration(),  0.001);
+            assertEquals(0.030, zgc.getPauseMarkEndDuration(),  0.001);
+            assertEquals(7.001d , zgc.getConcurrentProcessNonStrongReferencesDuration(),  0.001);
+            assertEquals(0.002d,zgc.getConcurrentResetRelocationSetDuration(),  0.001);
+            assertEquals(14.503d, zgc.getConcurrentSelectRelocationSetDuration(),  0.001);
+            assertEquals(0.027d, zgc.getPauseRelocateStartDuration(),  0.001);
+            assertEquals(13.827d,zgc.getConcurrentRelocateDuration(),  0.001);
+
+            //Memory
+            assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkStart(), 3072000, 2938880, 133120));
+            assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkEnd(), 3072000, 2998272, 73728 ));
+            assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateStart(),3072000, 2996224, 75776));
+            assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateEnd(), 3072000, 2996224, 75776));
+
+            assertTrue(checkZGCMetaSpaceSummary(zgc.getMetaspace(),22528, 22528, 1114112));
+
+            assertTrue(checkOccupancySummary(zgc.getLive(), 16384, 16384, 16384));
+            assertTrue(checkOccupancySummary(zgc.getAllocated(), 4096, 4096, 23552));
+            assertTrue(checkOccupancySummary(zgc.getGarbage(), 115712, 115712, 32768));
+
+            assertTrue(checkReclaimSummary(zgc.getReclaimed(), 0, 82944));
+            assertTrue(checkReclaimSummary(zgc.getMemorySummary(), 133120, 75776));
+
+            assertEquals(9.07, zgc.getLoadAverageAt(1));
+            assertEquals(9.48, zgc.getLoadAverageAt(5));
+            assertEquals(10.07, zgc.getLoadAverageAt(15));
+
+            assertEquals(96.7, zgc.getMMU(2));
+            assertEquals(98.7, zgc.getMMU(5));
+            assertEquals(99.3, zgc.getMMU(10));
+            assertEquals(99.7, zgc.getMMU(20));
+            assertEquals(99.8, zgc.getMMU(50));
+            assertEquals(99.9, zgc.getMMU(100));
+
+        } catch (Throwable t) {
+            fail(t);
+        }
+    }
+
     private boolean checkZGCMetaSpaceSummary(ZGCMetaspaceSummary summary, long used, long committed, long reserved) {
         return summary.getUsed() == used && summary.getCommitted() == committed && summary.getReserved() == reserved;
     }


### PR DESCRIPTION
Hi, here is a enhance for Generational ZGC , towards https://github.com/microsoft/gctoolkit/issues/364

major changes:
1. Some events(PauseMark,ConcurrentMark, etc.) occur twice in a single Cycle,  using their first timestamp.
2. Sum the event durations and memory occupancies (live/garbage/allocated) for the young generation and old generation.