### PR TITLE
dep updates 02 july 2024

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.1/maven-wrapper-3.3.1.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -56,44 +56,44 @@
 
     <properties>
         <revision>3.0.3-SNAPSHOT</revision>
-        <checkstyle.version>10.16.0</checkstyle.version>
-        <jreleaser.plugin.version>1.12.0</jreleaser.plugin.version>
-        <junit5.version>5.10.2</junit5.version>
+        <checkstyle.version>10.17.0</checkstyle.version>
+        <jreleaser.plugin.version>1.13.1</jreleaser.plugin.version>
+        <junit5.version>5.10.3</junit5.version>
         <maven.antrun-plugin.version>3.1.0</maven.antrun-plugin.version>
         <maven.changes-plugin.version>2.12.1</maven.changes-plugin.version>
-        <maven.checkstyle-plugin.version>3.3.1</maven.checkstyle-plugin.version>
-        <maven.clean-plugin.version>3.3.2</maven.clean-plugin.version>
+        <maven.checkstyle-plugin.version>3.4.0</maven.checkstyle-plugin.version>
+        <maven.clean-plugin.version>3.4.0</maven.clean-plugin.version>
         <maven.compiler-plugin.version>3.13.0</maven.compiler-plugin.version>
         <maven.compiler.release>11</maven.compiler.release>
-        <maven.dependency-plugin.version>3.6.1</maven.dependency-plugin.version>
+        <maven.dependency-plugin.version>3.7.1</maven.dependency-plugin.version>
         <maven.deploy-plugin.version>3.1.2</maven.deploy-plugin.version>
         <maven.directory-maven-plugin.version>1.0</maven.directory-maven-plugin.version>
-        <maven.enforcer-plugin.version>3.4.1</maven.enforcer-plugin.version>
-        <maven.exec-plugin.version>3.2.0</maven.exec-plugin.version>
+        <maven.enforcer-plugin.version>3.5.0</maven.enforcer-plugin.version>
+        <maven.exec-plugin.version>3.3.0</maven.exec-plugin.version>
         <maven.install-plugin.version>3.1.2</maven.install-plugin.version>
         <maven.jacoco-plugin.version>0.8.12</maven.jacoco-plugin.version>
-        <maven.jar-plugin.version>3.4.1</maven.jar-plugin.version>
-        <maven.javadoc-plugin.version>3.6.3</maven.javadoc-plugin.version>
-        <maven.jxr-plugin.version>3.3.2</maven.jxr-plugin.version>
+        <maven.jar-plugin.version>3.4.2</maven.jar-plugin.version>
+        <maven.javadoc-plugin.version>3.7.0</maven.javadoc-plugin.version>
+        <maven.jxr-plugin.version>3.4.0</maven.jxr-plugin.version>
         <maven.license-plugin.version>2.4.0</maven.license-plugin.version>
         <!-- TODO Upgrade to 3.22.0+ once we move to PMD 7.1.0+ -->
         <maven.pmd-plugin.version>3.21.2</maven.pmd-plugin.version>
-        <maven.project-info-reports-plugin.version>3.5.0</maven.project-info-reports-plugin.version>
+        <maven.project-info-reports-plugin.version>3.6.1</maven.project-info-reports-plugin.version>
         <maven.rat-plugin.version>0.16.1</maven.rat-plugin.version>
         <maven.resources-plugin.version>3.3.1</maven.resources-plugin.version>
-        <maven.site-plugin.version>4.0.0-M14</maven.site-plugin.version>
+        <maven.site-plugin.version>4.0.0-M15</maven.site-plugin.version>
         <maven.source-plugin.version>3.3.1</maven.source-plugin.version>
-        <maven.spotbugs-plugin.version>4.8.5.0</maven.spotbugs-plugin.version>
-        <maven.surefire-plugin.version>3.2.5</maven.surefire-plugin.version>
-        <maven.version>3.9.6</maven.version>
-        <maven.versions-plugin.version>2.16.2</maven.versions-plugin.version>
+        <maven.spotbugs-plugin.version>4.8.6.1</maven.spotbugs-plugin.version>
+        <maven.surefire-plugin.version>3.3.0</maven.surefire-plugin.version>
+        <maven.version>3.9.8</maven.version>
+        <maven.versions-plugin.version>2.17.0</maven.versions-plugin.version>
         <mutability.detector.version>0.9.1</mutability.detector.version>
-        <!-- TODO Migrate to 7.1.0 -->
+        <!-- TODO Migrate to 7.3.0 -->
         <pmd.version>6.55.0</pmd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.github.repository>microsoft/gctoolkit</project.github.repository>
         <repository.url>git@github.com:${project.github.repository}.git</repository.url>
-        <spotbugs.version>4.8.5</spotbugs.version>
+        <spotbugs.version>4.8.6</spotbugs.version>
     </properties>
 
     <modules>
@@ -379,7 +379,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <version>1.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>

--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>4.5.7</version>
+            <version>4.5.8</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
- **Fill in region summaries for G1GCFull (#315)**
- **Update dependencies and ability to pass in compile version (#314)**
- **Fix YAML for ea workflow (#317)**
- **Correct CMSTenuredPoolParser (#320)**
- **Bump actions/cache from 3.3.2 to 3.3.3 (#321)**
- **Bump actions/cache from 3.3.3 to 4.0.0 (#322)**
- **Catch IllegalArgumentException (#325)**
- **Move g1 heapRegionSize from class variable to member variable (#324)**
- **Mark ConcurrentModeFailure and ConcurrentModeInterrupted as CMSPhase (#326)**
- **Latest dependencies (#329)**
- **Issue 316 (#331)**
- **Bump actions/setup-java from 4.0.0 to 4.1.0 (#334)**
- **Bump actions/cache from 4.0.0 to 4.0.1 (#335)**
- **Fix cms corner case (#332)**
- **Collapse of CMSParser into GenerationHeapParser (#337)**
- **Bump actions/checkout from 4.1.1 to 4.1.2 (#339)**
- **Bump actions/setup-java from 4.1.0 to 4.2.0 (#341)**
- **Bump actions/setup-java from 4.2.0 to 4.2.1 (#342)**
- **Bump actions/cache from 4.0.1 to 4.0.2 (#343)**
- **I need a title (#344)**
- **Update to latest versions (#345)**
- **PreUnified now works with DateStamps only (#347)**
- **Bump actions/checkout from 4.1.2 to 4.1.3 (#349)**
- **Bump actions/checkout from 4.1.3 to 4.1.4 (#350)**
- **Bump actions/checkout from 4.1.4 to 4.1.5 (#353)**
- **Update dependencies (#354)**
- **Bump actions/checkout from 4.1.5 to 4.1.6 (#356)**
- **Bump actions/checkout from 4.1.6 to 4.1.7 (#363)**
- **Fix for gctoolkit #352 (Generational Heap Parser fails to recognize parallel gc lines) (#362)**
- **Estimate the start time by variance (#360)**
- **Add Evacuation workers getter for G1 GC (#366)**
- **Dependencies and plugins updated to latest possible**
