### PR TITLE
Improve Archive Region Calculation (#211)

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
@@ -544,6 +544,7 @@ class G1GCForwardReference extends ForwardReference {
         SurvivorMemoryPoolSummary survivor = getSurvivorMemoryPoolSummary();
         MemoryPoolSummary tenured = getMemoryPoolSummary(OLD_OCCUPANCY_BEFORE_COLLECTION);
         MemoryPoolSummary humongous = getMemoryPoolSummary(HUMONGOUS_OCCUPANCY_BEFORE_COLLECTION);
+        collection.addHeapRegionSize(heapRegionSize);
         if (heap != null && eden != null && survivor != null) {
             collection.addMemorySummary(eden, survivor, heap);
         } else if (eden == null && survivor == null && heap != null) {

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -494,7 +494,7 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
                 forwardReference.setHumongousRegionSummary(summary);
                 break;
             case "Archive":
-                  // Archive Region type is only available in JDK 14 and 17.
+                // Archive Region type is only available in JDK 14 and 17.
                 forwardReference.setArchiveRegionSummary(summary);
                 break;
             default:

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -495,7 +495,6 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
                 break;
             case "Archive":
                   // Archive Region type is only available in JDK 14 and 17.
-                 */
                 forwardReference.setArchiveRegionSummary(summary);
                 break;
             default:

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -494,7 +494,6 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
                 forwardReference.setHumongousRegionSummary(summary);
                 break;
             case "Archive":
-                /*
                   Archive Region type is only available in JDK 14 and 17.
                  */
                 forwardReference.setArchiveRegionSummary(summary);

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -494,6 +494,9 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
                 forwardReference.setHumongousRegionSummary(summary);
                 break;
             case "Archive":
+                /*
+                  Archive Region type is only available in JDK 14 and 17.
+                 */
                 forwardReference.setArchiveRegionSummary(summary);
                 break;
             default:

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -494,7 +494,7 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
                 forwardReference.setHumongousRegionSummary(summary);
                 break;
             case "Archive":
-                  Archive Region type is only available in JDK 14 and 17.
+                  // Archive Region type is only available in JDK 14 and 17.
                  */
                 forwardReference.setArchiveRegionSummary(summary);
                 break;


### PR DESCRIPTION
Previously, GCToolkit recognized archive regions but did not use this data in its calculations. This change improves the accuracy of tenured generation metrics for G1GCPause events.