### PR TITLE
Issue #359: fix NPE when parsing gc log file without any events

### DIFF
--- a/IT/src/test/java/com/microsoft/gctoolkit/integration/DirtyDataIntegrationTest.java
+++ b/IT/src/test/java/com/microsoft/gctoolkit/integration/DirtyDataIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.microsoft.gctoolkit.integration;
+
+import com.microsoft.gctoolkit.GCToolKit;
+import com.microsoft.gctoolkit.integration.aggregation.CollectionCycleCountsSummary;
+import com.microsoft.gctoolkit.integration.io.TestLogFile;
+import com.microsoft.gctoolkit.io.GCLogFile;
+import com.microsoft.gctoolkit.io.SingleGCLogFile;
+import com.microsoft.gctoolkit.parser.GenerationalHeapParser;
+import com.microsoft.gctoolkit.vertx.VertxDataSourceChannel;
+import com.microsoft.gctoolkit.vertx.VertxJVMEventChannel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("classPath")
+public class DirtyDataIntegrationTest {
+
+  /**
+   * Test a GC log file that contains only the header but no actual events
+   */
+  @Test
+  public void testNoEventLog() {
+    Path path = new TestLogFile("streaming/gc_no_event.log").getFile().toPath();
+    assertThrows(IllegalStateException.class, () -> analyze(path.toString()));
+  }
+
+  @Test
+  public void testEmptyFile() {
+    Path path = new TestLogFile("streaming/gc_empty.log").getFile().toPath();
+    assertThrows(IllegalStateException.class, () -> analyze(path.toString()));
+  }
+
+  public void analyze(String gcLogFile) throws IOException {
+    GCLogFile logFile = new SingleGCLogFile(Path.of(gcLogFile));
+    GCToolKit gcToolKit = new GCToolKit();
+
+    gcToolKit.loadDataSourceChannel(new VertxDataSourceChannel());
+    gcToolKit.loadJVMEventChannel(new VertxJVMEventChannel());
+    gcToolKit.loadDataSourceParser(new GenerationalHeapParser());
+
+    gcToolKit.loadAggregation(new CollectionCycleCountsSummary());
+
+    gcToolKit.analyze(logFile);
+  }
+}

--- a/IT/src/test/java/com/microsoft/gctoolkit/integration/DirtyDataIntegrationTest.java
+++ b/IT/src/test/java/com/microsoft/gctoolkit/integration/DirtyDataIntegrationTest.java
@@ -28,6 +28,9 @@ public class DirtyDataIntegrationTest {
     assertThrows(IllegalStateException.class, () -> analyze(path.toString()));
   }
 
+  /**
+   * Test an empty file that contains nothing
+   */
   @Test
   public void testEmptyFile() {
     Path path = new TestLogFile("streaming/gc_empty.log").getFile().toPath();

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogParser.java
@@ -53,6 +53,10 @@ public abstract class GCLogParser implements DataSourceParser, SharedPatterns {
     public void diary(Diary diary) {
         this.diary = diary;
         this.clock = diary.getTimeOfFirstEvent();
+        if (this.clock == null) {
+            LOGGER.log(Level.SEVERE, "Time of first event is null, are there any events presented in the log file?");
+            throw new IllegalStateException("Missing log events");
+        }
     }
 
     /**


### PR DESCRIPTION
Intended to fix issue #359.

About the fix:
1. Introduced a null guard. When `getClock()` is initially null, it means there is no event in the file. Therefore, we throw an exception to terminate the remaining process.

https://github.com/Lmh-java/gctoolkit/blob/9ee7fa33eca3b0309ca86ceb59bc667e0372e5de/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogParser.java#L53-L60

2. Added 2 test cases, which reproduces this issue and validate the fix (Test data files will be provided in another PR to the test data repo, once this PR is finalized).

Discussion:
1. Is termination through a RuntimeException the best way to end the process.
2. Probably a null guard in GCLogParser is not the best position?

I am not very familar with the project. Any advice is welcome and will be highly valued.
