### PR TITLE
ZGC Generational Support

### DIFF
--- a/IT/src/main/java/com/microsoft/gctoolkit/integration/aggregation/CollectionCycleCountsAggregator.java
+++ b/IT/src/main/java/com/microsoft/gctoolkit/integration/aggregation/CollectionCycleCountsAggregator.java
@@ -7,7 +7,9 @@ import com.microsoft.gctoolkit.event.g1gc.G1GCConcurrentEvent;
 import com.microsoft.gctoolkit.event.g1gc.G1GCPauseEvent;
 import com.microsoft.gctoolkit.event.generational.GenerationalGCPauseEvent;
 import com.microsoft.gctoolkit.event.shenandoah.ShenandoahCycle;
+import com.microsoft.gctoolkit.event.zgc.FullZGCCycle;
 import com.microsoft.gctoolkit.event.zgc.MajorZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.MinorZGCCycle;
 
 @Aggregates({EventSource.G1GC,EventSource.GENERATIONAL,EventSource.ZGC,EventSource.SHENANDOAH})
 public class CollectionCycleCountsAggregator extends Aggregator<CollectionCycleCountsAggregation> {
@@ -17,11 +19,21 @@ public class CollectionCycleCountsAggregator extends Aggregator<CollectionCycleC
         register(GenerationalGCPauseEvent.class, this::count);
         register(G1GCPauseEvent.class, this::count);
         register(G1GCConcurrentEvent.class, this::count);
+        register(FullZGCCycle.class,this::count);
         register(MajorZGCCycle.class,this::count);
+        register(MinorZGCCycle.class,this::count);
         register(ShenandoahCycle.class,this::count);
     }
 
+    private void count(FullZGCCycle event) {
+        aggregation().count(event.getGarbageCollectionType());
+    }
+
     private void count(MajorZGCCycle event) {
+        aggregation().count(event.getGarbageCollectionType());
+    }
+
+    private void count(MinorZGCCycle event) {
         aggregation().count(event.getGarbageCollectionType());
     }
 

--- a/IT/src/main/java/com/microsoft/gctoolkit/integration/aggregation/HeapOccupancyAfterCollectionAggregator.java
+++ b/IT/src/main/java/com/microsoft/gctoolkit/integration/aggregation/HeapOccupancyAfterCollectionAggregator.java
@@ -6,7 +6,9 @@ import com.microsoft.gctoolkit.aggregator.EventSource;
 import com.microsoft.gctoolkit.event.g1gc.G1GCPauseEvent;
 import com.microsoft.gctoolkit.event.generational.GenerationalGCPauseEvent;
 import com.microsoft.gctoolkit.event.shenandoah.ShenandoahCycle;
+import com.microsoft.gctoolkit.event.zgc.FullZGCCycle;
 import com.microsoft.gctoolkit.event.zgc.MajorZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.MinorZGCCycle;
 
 @Aggregates({EventSource.G1GC,EventSource.GENERATIONAL,EventSource.ZGC,EventSource.SHENANDOAH})
 public class HeapOccupancyAfterCollectionAggregator extends Aggregator<HeapOccupancyAfterCollectionAggregation> {
@@ -15,8 +17,18 @@ public class HeapOccupancyAfterCollectionAggregator extends Aggregator<HeapOccup
         super(results);
         register(GenerationalGCPauseEvent.class, this::extractHeapOccupancy);
         register(G1GCPauseEvent.class, this::extractHeapOccupancy);
+        register(FullZGCCycle.class,this::extractHeapOccupancy);
         register(MajorZGCCycle.class,this::extractHeapOccupancy);
+        register(MinorZGCCycle.class,this::extractHeapOccupancy);
         register(ShenandoahCycle.class,this::extractHeapOccupancy);
+    }
+
+    private void extractHeapOccupancy(MinorZGCCycle event) {
+        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getYoungCycle().getMemorySummary().getEnd());
+    }
+
+    private void extractHeapOccupancy(MajorZGCCycle event) {
+        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary().getEnd());
     }
 
     private void extractHeapOccupancy(GenerationalGCPauseEvent event) {
@@ -29,8 +41,8 @@ public class HeapOccupancyAfterCollectionAggregator extends Aggregator<HeapOccup
             aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getHeap().getOccupancyAfterCollection());
     }
 
-    private void extractHeapOccupancy(MajorZGCCycle event) {
-        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getLive().getReclaimEnd());
+    private void extractHeapOccupancy(FullZGCCycle event) {
+        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary().getEnd());
     }
 
     private void extractHeapOccupancy(ShenandoahCycle event) {

--- a/api/src/main/java/com/microsoft/gctoolkit/event/GCCause.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/GCCause.java
@@ -7,7 +7,6 @@ package com.microsoft.gctoolkit.event;
  * causes that a GC log file can hold.
  */
 public enum GCCause {
-
     JAVA_LANG_SYSTEM("System.gc()"),
     DIAGNOSTIC_COMMAND("Diagnostic Command"),
     FULL_GC_ALOT("FullGCALot"),
@@ -47,13 +46,16 @@ public enum GCCause {
     WHITEBOX_CONCURRENT_MARK("WhiteBox Initiated Concurrent Mark"),
     WHITEBOX_FULL("WhiteBox Initiated Full GC"),
     META_CLEAR_SOFT_REF("Metadata GC Clear Soft References"),
+    PREVENTIVE("G1 Preventive Collection"),
+    CODE_CACHE_THRESHOLD("CodeCache GC Threshold"),
+
+    // ZGC Specific
     TIMER("Timer"),
     WARMUP("Warmup"),
     ALLOC_RATE("Allocation Rate"),
     ALLOC_STALL("Allocation Stall"),
     PROACTIVE("Proactive"),
-    PREVENTIVE("G1 Preventive Collection"),
-    CODE_CACHE_THRESHOLD("CodeCache GC Threshold");
+    HIGH_USAGE("High Usage");
 
     private final String label;
 
@@ -64,5 +66,4 @@ public enum GCCause {
     public String getLabel() {
         return label;
     }
-
 }

--- a/api/src/main/java/com/microsoft/gctoolkit/event/GCCause.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/GCCause.java
@@ -52,7 +52,8 @@ public enum GCCause {
     ALLOC_RATE("Allocation Rate"),
     ALLOC_STALL("Allocation Stall"),
     PROACTIVE("Proactive"),
-    PREVENTIVE("G1 Preventive Collection");
+    PREVENTIVE("G1 Preventive Collection"),
+    CODE_CACHE_THRESHOLD("CodeCache GC Threshold");
 
     private final String label;
 

--- a/api/src/main/java/com/microsoft/gctoolkit/event/GCCauses.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/GCCauses.java
@@ -52,6 +52,7 @@ public class GCCauses {
         Map.entry(ALLOC_RATE.getLabel(), ALLOC_RATE),
         Map.entry(ALLOC_STALL.getLabel(), ALLOC_STALL),
         Map.entry(PROACTIVE.getLabel(), PROACTIVE),
+        Map.entry(CODE_CACHE_THRESHOLD.getLabel(), CODE_CACHE_THRESHOLD),
         Map.entry(GCCause.PREVENTIVE.getLabel(),PREVENTIVE));
 
     public static GCCause get(String gcCauseName) {
@@ -113,4 +114,7 @@ public class GCCauses {
     PROACTIVE("Proactive");
     //JDK 17
     PREVENTATIVE("G1 Preventive Collection")
+    //JDK 21
+    CODE_CACHE_THRESHOLD("CodeCache GC Threshold")
+
  */

--- a/api/src/main/java/com/microsoft/gctoolkit/event/GCCauses.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/GCCauses.java
@@ -42,18 +42,21 @@ public class GCCauses {
         // Additional GCCauses not found in gcause.cp
         Map.entry(GCCause.CONCURRENT_MARK_STACK_OVERFLOW.getLabel(), GCCause.CONCURRENT_MARK_STACK_OVERFLOW),
         Map.entry(GCCause.G1GC_YOUNG.getLabel(), GCCause.G1GC_YOUNG),
-        //JDK 11
+        // JDK 11
         Map.entry(WHITEBOX_YOUNG.getLabel(), WHITEBOX_YOUNG),
         Map.entry(WHITEBOX_CONCURRENT_MARK.getLabel(), WHITEBOX_CONCURRENT_MARK),
         Map.entry(WHITEBOX_FULL.getLabel(), WHITEBOX_FULL),
         Map.entry(META_CLEAR_SOFT_REF.getLabel(), META_CLEAR_SOFT_REF),
+        Map.entry(CODE_CACHE_THRESHOLD.getLabel(), CODE_CACHE_THRESHOLD),
+        Map.entry(GCCause.PREVENTIVE.getLabel(),PREVENTIVE),
+
+        // ZGC Specific
         Map.entry(TIMER.getLabel(), TIMER),
         Map.entry(WARMUP.getLabel(), WARMUP),
         Map.entry(ALLOC_RATE.getLabel(), ALLOC_RATE),
         Map.entry(ALLOC_STALL.getLabel(), ALLOC_STALL),
         Map.entry(PROACTIVE.getLabel(), PROACTIVE),
-        Map.entry(CODE_CACHE_THRESHOLD.getLabel(), CODE_CACHE_THRESHOLD),
-        Map.entry(GCCause.PREVENTIVE.getLabel(),PREVENTIVE));
+        Map.entry(HIGH_USAGE.getLabel(), HIGH_USAGE));
 
     public static GCCause get(String gcCauseName) {
 

--- a/api/src/main/java/com/microsoft/gctoolkit/event/GarbageCollectionTypes.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/GarbageCollectionTypes.java
@@ -55,7 +55,9 @@ public enum GarbageCollectionTypes implements LabelledGCEventType {
     G1GCFull("Full"),
     G1Trap("G1GC Trap"),
     Unknown("Unknown"),
-    ZGCCycle("ZGC"),
+    ZGCFull("ZGC FULL"),
+    ZGCMajor("ZGC Major"),
+    ZGCMinor("ZGC Minor"),
     Shenandoah("Shenandoah");
 
     private final String label;

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
@@ -1,0 +1,299 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.gctoolkit.event.zgc;
+
+import com.microsoft.gctoolkit.event.GCCause;
+import com.microsoft.gctoolkit.event.GCEvent;
+import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
+import com.microsoft.gctoolkit.time.DateTimeStamp;
+
+public class FullZGCCycle extends GCEvent {
+    private ZGCCycle delegate;
+
+    public FullZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, GCCause cause, double duration) {
+        super(timeStamp, gcType, cause, duration);
+    }
+
+    public FullZGCCycle(DateTimeStamp timeStamp, double duration) {
+        super(timeStamp, duration);
+    }
+
+    public FullZGCCycle(DateTimeStamp timeStamp, GCCause cause, double duration) {
+        super(timeStamp, cause, duration);
+    }
+
+    public FullZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, double duration) {
+        super(timeStamp, gcType, duration);
+    }
+
+    public void setZGCCycle(ZGCCycle zgcCycle) {
+        this.delegate = zgcCycle;
+    }
+
+    public ZGCMarkSummary getMarkSummary() {
+        return delegate.getMarkSummary();
+    }
+
+    public DateTimeStamp getPauseMarkStartTimeStamp() {
+        return delegate.getPauseMarkStartTimeStamp();
+    }
+
+    public double getPauseMarkStartDuration() {
+        return delegate.getPauseMarkStartDuration();
+    }
+
+    public long getGcId() {
+        return delegate.getGcId();
+    }
+
+
+    public DateTimeStamp getConcurrentMarkTimeStamp() {
+        return delegate.getConcurrentMarkTimeStamp();
+    }
+
+    public double getConcurrentMarkDuration() {
+        return delegate.getConcurrentMarkDuration();
+    }
+
+    public DateTimeStamp getConcurrentMarkFreeTimeStamp() {
+        return delegate.getConcurrentMarkFreeTimeStamp();
+    }
+
+    public double getConcurrentMarkFreeDuration() {
+        return delegate.getConcurrentMarkFreeDuration();
+    }
+
+    public DateTimeStamp getPauseMarkEndTimeStamp() {
+        return delegate.getPauseMarkEndTimeStamp();
+    }
+
+    public double getPauseMarkEndDuration() {
+        return delegate.getPauseMarkEndDuration();
+    }
+
+
+    public DateTimeStamp getConcurrentProcessNonStrongReferencesTimeStamp() {
+        return delegate.getConcurrentProcessNonStrongReferencesTimeStamp();
+    }
+
+    public double getConcurrentProcessNonStrongReferencesDuration() {
+        return delegate.getConcurrentProcessNonStrongReferencesDuration();
+    }
+
+    public DateTimeStamp getConcurrentResetRelocationSetTimeStamp() {
+        return delegate.getConcurrentResetRelocationSetTimeStamp();
+    }
+
+    public double getConcurrentResetRelocationSetDuration() {
+        return delegate.getConcurrentResetRelocationSetDuration();
+    }
+
+    public DateTimeStamp getConcurrentSelectRelocationSetTimeStamp() {
+        return delegate.getConcurrentSelectRelocationSetTimeStamp();
+    }
+
+    public double getConcurrentSelectRelocationSetDuration() {
+        return delegate.getConcurrentSelectRelocationSetDuration();
+    }
+
+    public DateTimeStamp getPauseRelocateStartTimeStamp() {
+        return delegate.getPauseRelocateStartTimeStamp();
+    }
+
+    public double getPauseRelocateStartDuration() {
+        return delegate.getPauseRelocateStartDuration();
+    }
+
+    public DateTimeStamp getConcurrentRelocateTimeStamp() {
+        return delegate.getConcurrentRelocateTimeStamp();
+    }
+
+    public double getConcurrentRelocateDuration() {
+        return delegate.getConcurrentRelocateDuration();
+    }
+
+    public ZGCMemoryPoolSummary getMarkStart() {
+        return delegate.getMarkStart();
+    }
+
+    public ZGCMemoryPoolSummary getMarkEnd() {
+        return delegate.getMarkEnd();
+    }
+
+    public ZGCMemoryPoolSummary getRelocateStart() {
+        return delegate.getRelocateStart();
+    }
+
+    public ZGCMemoryPoolSummary getRelocateEnd() {
+        return delegate.getRelocateEnd();
+    }
+
+    public ZGCLiveSummary getLive() {
+        return delegate.getLiveSummary();
+    }
+
+    public ZGCAllocatedSummary getAllocated() {
+        return delegate.getAllocatedSummary();
+    }
+
+    public ZGCGarbageSummary getGarbage() {
+        return delegate.getGarbageSummary();
+    }
+
+    public ZGCReclaimSummary getReclaimed() {
+        return delegate.getReclaimSummary();
+    }
+
+    public ZGCMemorySummary getMemorySummary() {
+        return delegate.getMemorySummary();
+    }
+
+    public ZGCMetaspaceSummary getMetaspace() {
+        return delegate.getMetaspaceSummary();
+    }
+
+    public double getLoadAverageAt(int time) {
+        return delegate.getLoadAverageAt(time);
+    }
+
+    public double getMMU(int percentage) {
+        return delegate.getMMU(percentage);
+    }
+
+    public ZGCPromotedSummary getPromotedSummary() {
+        return delegate.getPromotedSummary();
+    }
+
+    public ZGCCompactedSummary getCompactedSummary() {
+        return delegate.getCompactedSummary();
+    }
+
+    public OccupancySummary getUsedOccupancySummary() {
+        return delegate.getUsedOccupancySummary();
+    }
+
+    public ZGCCollectionType getType() {
+        return delegate.getType();
+    }
+
+    public DateTimeStamp getMarkRootsStart() {
+        return delegate.getMarkRootsStart();
+    }
+
+    public double getMarkRootsDuration() {
+        return delegate.getMarkRootsDuration();
+    }
+
+    public DateTimeStamp getMarkFollowStart() {
+        return delegate.getMarkFollowStart();
+    }
+
+    public double getMarkFollowDuration() {
+        return delegate.getMarkFollowDuration();
+    }
+
+    public DateTimeStamp getRemapRootColoredStart() {
+        return delegate.getRemapRootColoredStart();
+    }
+
+    public double getRemapRootsColoredDuration() {
+        return delegate.getRemapRootsColoredDuration();
+    }
+
+    public DateTimeStamp getRemapRootsUncoloredStart() {
+        return delegate.getRemapRootsUncoloredStart();
+    }
+
+    public double getRemapRootsUncoloredDuration() {
+        return delegate.getRemapRootsUncoloredDuration();
+    }
+
+    public DateTimeStamp getRemapRememberedStart() {
+        return delegate.getRemapRememberedStart();
+    }
+
+    public double getRemapRememberedDuration() {
+        return delegate.getRemapRememberedDuration();
+    }
+
+    public double getPauseMarkRelocateDuration() {
+        return delegate.getPauseMarkRelocateDuration();
+    }
+
+    public DateTimeStamp getConcurrentMarkContinueTimeStamp() {
+        return delegate.getConcurrentMarkContinueTimeStamp();
+    }
+
+    public double getConcurrentMarkContinueDuration() {
+        return delegate.getConcurrentMarkContinueDuration();
+    }
+
+    public DateTimeStamp getRemapRootsStart() {
+        return delegate.getConcurrentRemapRootsStart();
+    }
+
+    public double getRemapRootsDuration() {
+        return delegate.getConcurrentRemapRootsDuration();
+    }
+
+    public double[] getLoad() {
+        return delegate.getLoad();
+    }
+
+    public double[] getMmu() {
+        return delegate.getMmu();
+    }
+}
+
+// Concurrent Mark duration
+// Pause mark end duration
+// Concurrent reference processing duration
+// Concurrent reset relocation set duration
+// Concurrent select relocation set duration
+// Pause relocate start
+// Load
+// MMU
+// Concurrent relocate
+// Relocation volume
+// NMethods, registered, unregistered
+// Metaspace used, capacity committed, reserved
+// Soft, weak, final, phantom.. encountered, discovered, enqueued
+// Memory stats
+
+/*
+[32.121s][info][gc,start    ] GC(2) Garbage Collection (Metadata GC Threshold)
+[32.121s][info][gc,phases   ] GC(2) Pause Mark Start 0.023ms
+[32.166s][info][gc,phases   ] GC(2) Concurrent Mark 44.623ms
+[32.166s][info][gc,phases   ] GC(2) Pause Mark End 0.029ms
+[32.166s][info][gc,phases   ] GC(2) Concurrent Mark Free 0.001ms
+[32.172s][info][gc,phases   ] GC(2) Concurrent Process Non-Strong References 5.797ms
+[32.172s][info][gc,phases   ] GC(2) Concurrent Reset Relocation Set 0.012ms
+[32.178s][info][gc,phases   ] GC(2) Concurrent Select Relocation Set 6.446ms
+[32.179s][info][gc,phases   ] GC(2) Pause Relocate Start 0.024ms
+[32.193s][info][gc,phases   ] GC(2) Concurrent Relocate 14.013ms
+[32.193s][info][gc,load     ] GC(2) Load: 7.28/6.63/5.01
+[32.193s][info][gc,mmu      ] GC(2) MMU: 2ms/98.2%, 5ms/99.3%, 10ms/99.5%, 20ms/99.7%, 50ms/99.9%, 100ms/99.9%
+[32.193s][info][gc,marking  ] GC(2) Mark: 4 stripe(s), 3 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s)
+[32.193s][info][gc,marking  ] GC(2) Mark Stack Usage: 32M
+[32.193s][info][gc,metaspace] GC(2) Metaspace: 60M used, 60M committed, 1080M reserved
+[32.193s][info][gc,ref      ] GC(2) Soft: 5447 encountered, 0 discovered, 0 enqueued
+[32.193s][info][gc,ref      ] GC(2) Weak: 5347 encountered, 2016 discovered, 810 enqueued
+[32.193s][info][gc,ref      ] GC(2) Final: 1041 encountered, 113 discovered, 105 enqueued
+[32.193s][info][gc,ref      ] GC(2) Phantom: 558 encountered, 501 discovered, 364 enqueued
+[32.193s][info][gc,reloc    ] GC(2) Small Pages: 235 / 470M, Empty: 32M, Relocated: 40M, In-Place: 0
+[32.193s][info][gc,reloc    ] GC(2) Medium Pages: 2 / 64M, Empty: 0M, Relocated: 3M, In-Place: 0
+[32.193s][info][gc,reloc    ] GC(2) Large Pages: 3 / 24M, Empty: 8M, Relocated: 0M, In-Place: 0
+[32.193s][info][gc,reloc    ] GC(2) Forwarding Usage: 13M
+[32.193s][info][gc,heap     ] GC(2) Min Capacity: 8M(0%)
+[32.193s][info][gc,heap     ] GC(2) Max Capacity: 28686M(100%)
+[32.193s][info][gc,heap     ] GC(2) Soft Max Capacity: 28686M(100%)
+[32.193s][info][gc,heap     ] GC(2)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low
+[32.193s][info][gc,heap     ] GC(2)  Capacity:     1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)
+[32.193s][info][gc,heap     ] GC(2)      Free:    28128M (98%)       28110M (98%)       28148M (98%)       28560M (100%)      28560M (100%)      28108M (98%)
+[32.193s][info][gc,heap     ] GC(2)      Used:      558M (2%)          576M (2%)          538M (2%)          126M (0%)          578M (2%)          126M (0%)
+[32.193s][info][gc,heap     ] GC(2)      Live:         -                71M (0%)           71M (0%)           71M (0%)             -                  -
+[32.193s][info][gc,heap     ] GC(2) Allocated:         -                18M (0%)           20M (0%)           18M (0%)             -                  -
+[32.193s][info][gc,heap     ] GC(2)   Garbage:         -               486M (2%)          446M (2%)           35M (0%)             -                  -
+[32.193s][info][gc,heap     ] GC(2) Reclaimed:         -                  -                40M (0%)          450M (2%)             -                  -
+[32.193s][info][gc          ] GC(2) Garbage Collection (Metadata GC Threshold) 558M(2%)->126M(0%)
+*/

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/MajorZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/MajorZGCCycle.java
@@ -3,10 +3,16 @@
 package com.microsoft.gctoolkit.event.zgc;
 
 import com.microsoft.gctoolkit.event.GCCause;
+import com.microsoft.gctoolkit.event.GCEvent;
 import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
-public class MajorZGCCycle extends ZGCCycle {
+public class MajorZGCCycle extends GCEvent {
+    private ZGCCycle oldCycle;
+    private ZGCCycle youngCycle;
+    private ZGCMemorySummary memorySummary;
+    private long gcId;
+
     public MajorZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, GCCause cause, double duration) {
         super(timeStamp, gcType, cause, duration);
     }
@@ -21,5 +27,38 @@ public class MajorZGCCycle extends ZGCCycle {
 
     public MajorZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, double duration) {
         super(timeStamp, gcType, duration);
+    }
+
+    public ZGCCycle getOldCycle() {
+        return oldCycle;
+    }
+
+    public void setOldCycle(ZGCCycle oldCycle) {
+        this.oldCycle = oldCycle;
+    }
+
+    public ZGCCycle getYoungCycle() {
+        return youngCycle;
+    }
+
+    public void setYoungCycle(ZGCCycle youngCycle) {
+        this.youngCycle = youngCycle;
+    }
+
+    public ZGCMemorySummary getMemorySummary() {
+        return memorySummary;
+    }
+
+    public void setMemorySummary(ZGCMemorySummary memorySummary) {
+        this.memorySummary = memorySummary;
+    }
+
+    public void setGcId(long gcId) {
+
+        this.gcId = gcId;
+    }
+
+    public long getGcId() {
+        return gcId;
     }
 }

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/MinorZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/MinorZGCCycle.java
@@ -3,10 +3,15 @@
 package com.microsoft.gctoolkit.event.zgc;
 
 import com.microsoft.gctoolkit.event.GCCause;
+import com.microsoft.gctoolkit.event.GCEvent;
 import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
-public class MinorZGCCycle extends MajorZGCCycle {
+public class MinorZGCCycle extends GCEvent {
+    private ZGCCycle youngCycle;
+    private ZGCMemorySummary memorySummary;
+    private long gcId;
+
     public MinorZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, GCCause cause, double duration) {
         super(timeStamp, gcType, cause, duration);
     }
@@ -21,5 +26,30 @@ public class MinorZGCCycle extends MajorZGCCycle {
 
     public MinorZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, double duration) {
         super(timeStamp, gcType, duration);
+    }
+
+    public ZGCCycle getYoungCycle() {
+        return youngCycle;
+    }
+
+    public void setYoungCycle(ZGCCycle youngCycle) {
+        this.youngCycle = youngCycle;
+    }
+
+    public ZGCMemorySummary getMemorySummary() {
+        return memorySummary;
+    }
+
+    public void setMemorySummary(ZGCMemorySummary memorySummary) {
+        this.memorySummary = memorySummary;
+    }
+
+    public void setGcId(long gcId) {
+
+        this.gcId = gcId;
+    }
+
+    public long getGcId() {
+        return gcId;
     }
 }

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/OccupancySummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/OccupancySummary.java
@@ -3,13 +3,13 @@
 package com.microsoft.gctoolkit.event.zgc;
 
 public class OccupancySummary {
-
+    private final long markStart;
     private final long markEnd;
     private final long reclaimStart;
     private final long reclaimEnd;
 
-
-    public OccupancySummary(long markEnd, long reclaimStart, long reclaimEnd) {
+    public OccupancySummary(long markStart, long markEnd, long reclaimStart, long reclaimEnd) {
+        this.markStart = markStart;
         this.markEnd = markEnd;
         this.reclaimStart = reclaimStart;
         this.reclaimEnd = reclaimEnd;
@@ -27,10 +27,14 @@ public class OccupancySummary {
         return reclaimEnd;
     }
 
+    public long getMarkStart() {
+        return markStart;
+    }
+
     public OccupancySummary sum(OccupancySummary other) {
         if (other == null) {
             return this;
         }
-        return new OccupancySummary(markEnd + other.markEnd, reclaimStart + other.reclaimStart, reclaimEnd + other.reclaimEnd);
+        return new OccupancySummary(markStart + other.markStart, markEnd + other.markEnd, reclaimStart + other.reclaimStart, reclaimEnd + other.reclaimEnd);
     }
 }

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCAllocatedSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCAllocatedSummary.java
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCAllocatedSummary {
+    private final long markEnd;
+    private final long relocateStart;
+    private final long relocateEnd;
+
+    public ZGCAllocatedSummary(long markEnd, long relocateStart, long relocateEnd) {
+        this.markEnd = markEnd;
+        this.relocateStart = relocateStart;
+        this.relocateEnd = relocateEnd;
+    }
+
+    public long getMarkEnd() {
+        return markEnd;
+    }
+
+    public long getRelocateStart() {
+        return relocateStart;
+    }
+
+    public long getRelocateEnd() {
+        return relocateEnd;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCollectionType.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCollectionType.java
@@ -1,0 +1,22 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public enum ZGCCollectionType {
+    FULL("Garbage"), // Legacy ZGC
+    MINOR("Minor"),
+    MAJOR("Major");
+
+    private final String collectionLabel;
+
+    ZGCCollectionType(String collectionLabel) {
+        this.collectionLabel = collectionLabel;
+    }
+
+    public static ZGCCollectionType get(String label) {
+        for (ZGCCollectionType status : ZGCCollectionType.values()) {
+            if (status.collectionLabel.equalsIgnoreCase(label.trim())) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("No matching ZGCCollectionType found for: " + label);
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCompactedSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCompactedSummary.java
@@ -1,0 +1,13 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCCompactedSummary {
+    private final long relocateEnd;
+
+    public ZGCCompactedSummary(long relocateEnd) {
+        this.relocateEnd = relocateEnd;
+    }
+
+    public long getRelocateEnd() {
+        return relocateEnd;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
@@ -1,60 +1,91 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 package com.microsoft.gctoolkit.event.zgc;
 
-import com.microsoft.gctoolkit.event.GCCause;
-import com.microsoft.gctoolkit.event.GCEvent;
-import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
-public class ZGCCycle extends GCEvent {
-    public ZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, GCCause cause, double duration) {
-        super(timeStamp, gcType, cause, duration);
-    }
-
-    public ZGCCycle(DateTimeStamp timeStamp, double duration) {
-        super(timeStamp, duration);
-    }
-
-    public ZGCCycle(DateTimeStamp timeStamp, GCCause cause, double duration) {
-        super(timeStamp, cause, duration);
-    }
-
-    public ZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, double duration) {
-        super(timeStamp, gcType, duration);
-    }
-
+public class ZGCCycle {
+    private DateTimeStamp markRootsStart;
+    private double markRootsDuration;
+    private DateTimeStamp markFollowStart;
+    private double markFollowDuration;
+    private DateTimeStamp remapRootColoredStart;
+    private double remapRootsColoredDuration;
+    private DateTimeStamp remapRootsUncoloredStart;
+    private double remapRootsUncoloredDuration;
+    private DateTimeStamp remapRememberedStart;
+    private double remapRememberedDuration;
+    private ZGCMarkSummary markSummary;
+    private ZGCPromotedSummary promotedSummary;
+    private ZGCCompactedSummary compactedSummary;
+    private ZGCCollectionType type;
+    private ZGCPhase phase;
+    private OccupancySummary usedOccupancySummary;
     private long gcId;
-
     private DateTimeStamp pauseMarkStartTimeStamp;
     private double pauseMarkStartDuration;
-
     private DateTimeStamp concurrentMarkTimeStamp;
     private double concurrentMarkDuration;
-
     private DateTimeStamp concurrentMarkFreeTimeStamp;
     private double concurrentMarkFreeDuration;
-
     private DateTimeStamp pauseMarkEndTimeStamp;
     private double pauseMarkEndDuration;
-
     private DateTimeStamp concurrentProcessNonStrongReferencesTimeStamp;
     private double concurrentProcessNonStrongReferencesDuration;
-
     private DateTimeStamp concurrentResetRelocationSetTimeStamp;
     private double concurrentResetRelocationSetDuration;
-
     private DateTimeStamp concurrentSelectRelocationSetTimeStamp;
     private double concurrentSelectRelocationSetDuration;
-
     private DateTimeStamp pauseRelocateStartTimeStamp;
     private double pauseMarkRelocateDuration;
-
     private DateTimeStamp concurrentRelocateTimeStamp;
     private double concurrentRelocateDuration;
-
+    private DateTimeStamp concurrentMarkContinueTimeStamp;
+    private double concurrentMarkContinueDuration;
+    private DateTimeStamp concurrentRemapRootsStart;
+    private double concurrentRemapRootsDuration;
     private double[] load = new double[3];
     private double[] mmu = new double[6];
+
+    //Memory
+    private ZGCMemoryPoolSummary markStart;
+    private ZGCMemoryPoolSummary markEnd;
+    private ZGCMemoryPoolSummary relocateStart;
+    private ZGCMemoryPoolSummary relocateEnd;
+
+    private ZGCLiveSummary liveSummary;
+    private ZGCAllocatedSummary allocatedSummary;
+    private ZGCGarbageSummary garbageSummary;
+    private ZGCReclaimSummary reclaimSummary;
+    private ZGCMemorySummary memorySummary;
+    private ZGCMetaspaceSummary metaspaceSummary;
+
+    public ZGCReferenceSummary getSoftRefSummary() {
+        return softRefSummary;
+    }
+
+    public ZGCReferenceSummary getWeakRefSummary() {
+        return weakRefSummary;
+    }
+
+    public ZGCReferenceSummary getFinalRefSummary() {
+        return finalRefSummary;
+    }
+
+    public ZGCReferenceSummary getPhantomRefSummary() {
+        return phantomRefSummary;
+    }
+
+    private ZGCReferenceSummary softRefSummary;
+    private ZGCReferenceSummary weakRefSummary;
+    private ZGCReferenceSummary finalRefSummary;
+    private ZGCReferenceSummary phantomRefSummary;
+
+    public ZGCMarkSummary getMarkSummary() {
+        return markSummary;
+    }
+
+    public void setMarkSummary(ZGCMarkSummary markSummary) {
+        this.markSummary = markSummary;
+    }
 
     public DateTimeStamp getPauseMarkStartTimeStamp() {
         return pauseMarkStartTimeStamp;
@@ -181,101 +212,95 @@ public class ZGCCycle extends GCEvent {
         this.concurrentRelocateDuration = duration;
     }
 
-    //Memory
-    private ZGCMemoryPoolSummary markStart;
-    private ZGCMemoryPoolSummary markEnd;
-    private ZGCMemoryPoolSummary relocateStart;
-    private ZGCMemoryPoolSummary relocateEnd;
-    private OccupancySummary live;
-    private OccupancySummary allocated;
-    private OccupancySummary garbage;
-    private ReclaimSummary reclaimed;
-    private ReclaimSummary memorySummary;
-    private ZGCMetaspaceSummary metaspace;
-
-    public void setMarkStart(ZGCMemoryPoolSummary summary) {
-        this.markStart = summary;
-    }
-
-    public void setMarkEnd(ZGCMemoryPoolSummary summary) {
-        this.markEnd = summary;
-    }
-
-    public void setRelocateStart(ZGCMemoryPoolSummary summary) {
-        this.relocateStart = summary;
-    }
-
-    public void setRelocateEnd(ZGCMemoryPoolSummary summary) {
-        this.relocateEnd = summary;
-    }
-
-    public void setLive(OccupancySummary summary) {
-        this.live = summary;
-    }
-
-    public void setAllocated(OccupancySummary summary) {
-        this.allocated = summary;
-    }
-
-    public void setGarbage(OccupancySummary summary) {
-        this.garbage = summary;
-    }
-
-    public void setReclaimed(ReclaimSummary summary) {
-        this.reclaimed = summary;
-    }
-
-    public void setMemorySummary(ReclaimSummary summary) {
-        this.memorySummary = summary;
-    }
-
-    public void setMetaspace(ZGCMetaspaceSummary summary) {
-        this.metaspace = summary;
+    public void setConcurrentMarkContinue(DateTimeStamp concurrentMarkContinueTimeStamp, double duration) {
+        this.concurrentMarkContinueTimeStamp = concurrentMarkContinueTimeStamp;
+        this.concurrentMarkContinueDuration = duration;
     }
 
     public ZGCMemoryPoolSummary getMarkStart() {
         return markStart;
     }
 
+    public void setMarkStart(ZGCMemoryPoolSummary summary) {
+        this.markStart = summary;
+    }
+
     public ZGCMemoryPoolSummary getMarkEnd() {
         return markEnd;
+    }
+
+    public void setMarkEnd(ZGCMemoryPoolSummary summary) {
+        this.markEnd = summary;
     }
 
     public ZGCMemoryPoolSummary getRelocateStart() {
         return relocateStart;
     }
 
+    public void setRelocateStart(ZGCMemoryPoolSummary summary) {
+        this.relocateStart = summary;
+    }
+
     public ZGCMemoryPoolSummary getRelocateEnd() {
         return relocateEnd;
     }
 
-    public OccupancySummary getLive() {
-        return live;
+    public void setRelocateEnd(ZGCMemoryPoolSummary summary) {
+        this.relocateEnd = summary;
     }
 
-    public OccupancySummary getAllocated() {
-        return allocated;
+    public ZGCLiveSummary getLiveSummary() {
+        return liveSummary;
     }
 
-    public OccupancySummary getGarbage() {
-        return garbage;
+    public void setLiveSummary(ZGCLiveSummary summary) {
+        this.liveSummary = summary;
     }
 
-    public ReclaimSummary getReclaimed() {
-        return reclaimed;
+    public ZGCAllocatedSummary getAllocatedSummary() {
+        return allocatedSummary;
     }
 
-    public ReclaimSummary getMemorySummary() {
+    public void setAllocatedSummary(ZGCAllocatedSummary summary) {
+        this.allocatedSummary = summary;
+    }
+
+    public ZGCGarbageSummary getGarbageSummary() {
+        return garbageSummary;
+    }
+
+    public void setGarbageSummary(ZGCGarbageSummary summary) {
+        this.garbageSummary = summary;
+    }
+
+    public ZGCReclaimSummary getReclaimSummary() {
+        return reclaimSummary;
+    }
+
+    public void setReclaimSummary(ZGCReclaimSummary summary) {
+        this.reclaimSummary = summary;
+    }
+
+    public ZGCMemorySummary getMemorySummary() {
         return memorySummary;
     }
 
-    public ZGCMetaspaceSummary getMetaspace() {
-        return metaspace;
+    public void setMemorySummary(ZGCMemorySummary summary) {
+        this.memorySummary = summary;
+    }
+
+    public ZGCMetaspaceSummary getMetaspaceSummary() {
+        return metaspaceSummary;
+    }
+
+    public void setMetaspaceSummary(ZGCMetaspaceSummary summary) {
+        this.metaspaceSummary = summary;
     }
 
     public void setLoadAverages(double[] load) {
         this.load = load;
     }
+
     public double getLoadAverageAt(int time) {
         switch (time) {
             case 1:
@@ -311,57 +336,161 @@ public class ZGCCycle extends GCEvent {
                 return 0.0d;
         }
     }
+
+    public void setConcurrentRemapRoots(DateTimeStamp remapRootsStart, double remapRootsDuration) {
+        this.concurrentRemapRootsStart = remapRootsStart;
+        this.concurrentRemapRootsDuration = remapRootsDuration;
+    }
+
+    public void setMarkRoots(DateTimeStamp markRootsStart, double markRootsDuration) {
+        this.markRootsStart = markRootsStart;
+        this.markRootsDuration = markRootsDuration;
+    }
+
+    public void setMarkFollow(DateTimeStamp markFollowStart, double markFollowDuration) {
+        this.markFollowStart = markFollowStart;
+        this.markFollowDuration = markFollowDuration;
+    }
+
+    public void setRemapRootsColored(DateTimeStamp remapRootColoredStart, double remapRootsColoredDuration) {
+        this.remapRootColoredStart = remapRootColoredStart;
+        this.remapRootsColoredDuration = remapRootsColoredDuration;
+    }
+
+    public void setRemapRootsUncolored(DateTimeStamp remapRootsUncoloredStart, double remapRootsUncoloredDuration) {
+        this.remapRootsUncoloredStart = remapRootsUncoloredStart;
+        this.remapRootsUncoloredDuration = remapRootsUncoloredDuration;
+    }
+
+    public void setRemapRemembered(DateTimeStamp remapRememberedStart, double remapRememberedDuration) {
+
+        this.remapRememberedStart = remapRememberedStart;
+        this.remapRememberedDuration = remapRememberedDuration;
+    }
+
+    public ZGCPromotedSummary getPromotedSummary() {
+        return promotedSummary;
+    }
+
+    public void setPromotedSummary(ZGCPromotedSummary promotedSummary) {
+
+        this.promotedSummary = promotedSummary;
+    }
+
+    public ZGCCompactedSummary getCompactedSummary() {
+        return compactedSummary;
+    }
+
+    public void setCompactedSummary(ZGCCompactedSummary compactedSummary) {
+        this.compactedSummary = compactedSummary;
+    }
+
+    public void setusedOccupancySummary(OccupancySummary usedOccupancySummary) {
+
+        this.usedOccupancySummary = usedOccupancySummary;
+    }
+
+    public OccupancySummary getUsedOccupancySummary() {
+        return usedOccupancySummary;
+    }
+
+    public ZGCCollectionType getType() {
+        return type;
+    }
+
+    public void setType(ZGCCollectionType type) {
+        this.type = type;
+    }
+
+    public DateTimeStamp getMarkRootsStart() {
+        return markRootsStart;
+    }
+
+    public double getMarkRootsDuration() {
+        return markRootsDuration;
+    }
+
+    public DateTimeStamp getMarkFollowStart() {
+        return markFollowStart;
+    }
+
+    public double getMarkFollowDuration() {
+        return markFollowDuration;
+    }
+
+    public DateTimeStamp getRemapRootColoredStart() {
+        return remapRootColoredStart;
+    }
+
+    public double getRemapRootsColoredDuration() {
+        return remapRootsColoredDuration;
+    }
+
+    public DateTimeStamp getRemapRootsUncoloredStart() {
+        return remapRootsUncoloredStart;
+    }
+
+    public double getRemapRootsUncoloredDuration() {
+        return remapRootsUncoloredDuration;
+    }
+
+    public DateTimeStamp getRemapRememberedStart() {
+        return remapRememberedStart;
+    }
+
+    public double getRemapRememberedDuration() {
+        return remapRememberedDuration;
+    }
+
+    public double getPauseMarkRelocateDuration() {
+        return pauseMarkRelocateDuration;
+    }
+
+    public DateTimeStamp getConcurrentMarkContinueTimeStamp() {
+        return concurrentMarkContinueTimeStamp;
+    }
+
+    public double getConcurrentMarkContinueDuration() {
+        return concurrentMarkContinueDuration;
+    }
+
+    public DateTimeStamp getConcurrentRemapRootsStart() {
+        return concurrentRemapRootsStart;
+    }
+
+    public double getConcurrentRemapRootsDuration() {
+        return concurrentRemapRootsDuration;
+    }
+
+    public double[] getLoad() {
+        return load;
+    }
+
+    public double[] getMmu() {
+        return mmu;
+    }
+
+    public void setPhase(ZGCPhase phase) {
+        this.phase = phase;
+    }
+
+    public ZGCPhase getPhase() {
+        return phase;
+    }
+
+    public void setSoftRefSummary(ZGCReferenceSummary softRefSummary) {
+        this.softRefSummary = softRefSummary;
+    }
+
+    public void setWeakRefSummary(ZGCReferenceSummary weakRefSummary) {
+        this.weakRefSummary = weakRefSummary;
+    }
+
+    public void setFinalRefSummary(ZGCReferenceSummary finalRefSummary) {
+        this.finalRefSummary = finalRefSummary;
+    }
+
+    public void setPhantomRefSummary(ZGCReferenceSummary phantomRefSummary) {
+        this.phantomRefSummary = phantomRefSummary;
+    }
 }
-
-// Concurrent Mark duration
-// Pause mark end duration
-// Concurrent reference processing duration
-// Concurrent reset relocation set duration
-// Concurrent select relocation set duration
-// Pause relocate start
-// Load
-// MMU
-// Concurrent relocate
-// Relocation volume
-// NMethods, registered, unregistered
-// Metaspace used, capacity committed, reserved
-// Soft, weak, final, phantom.. encountered, discovered, enqueued
-// Memory stats
-
-/*
-[32.121s][info][gc,start    ] GC(2) Garbage Collection (Metadata GC Threshold)
-[32.121s][info][gc,phases   ] GC(2) Pause Mark Start 0.023ms
-[32.166s][info][gc,phases   ] GC(2) Concurrent Mark 44.623ms
-[32.166s][info][gc,phases   ] GC(2) Pause Mark End 0.029ms
-[32.166s][info][gc,phases   ] GC(2) Concurrent Mark Free 0.001ms
-[32.172s][info][gc,phases   ] GC(2) Concurrent Process Non-Strong References 5.797ms
-[32.172s][info][gc,phases   ] GC(2) Concurrent Reset Relocation Set 0.012ms
-[32.178s][info][gc,phases   ] GC(2) Concurrent Select Relocation Set 6.446ms
-[32.179s][info][gc,phases   ] GC(2) Pause Relocate Start 0.024ms
-[32.193s][info][gc,phases   ] GC(2) Concurrent Relocate 14.013ms
-[32.193s][info][gc,load     ] GC(2) Load: 7.28/6.63/5.01
-[32.193s][info][gc,mmu      ] GC(2) MMU: 2ms/98.2%, 5ms/99.3%, 10ms/99.5%, 20ms/99.7%, 50ms/99.9%, 100ms/99.9%
-[32.193s][info][gc,marking  ] GC(2) Mark: 4 stripe(s), 3 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s)
-[32.193s][info][gc,marking  ] GC(2) Mark Stack Usage: 32M
-[32.193s][info][gc,metaspace] GC(2) Metaspace: 60M used, 60M committed, 1080M reserved
-[32.193s][info][gc,ref      ] GC(2) Soft: 5447 encountered, 0 discovered, 0 enqueued
-[32.193s][info][gc,ref      ] GC(2) Weak: 5347 encountered, 2016 discovered, 810 enqueued
-[32.193s][info][gc,ref      ] GC(2) Final: 1041 encountered, 113 discovered, 105 enqueued
-[32.193s][info][gc,ref      ] GC(2) Phantom: 558 encountered, 501 discovered, 364 enqueued
-[32.193s][info][gc,reloc    ] GC(2) Small Pages: 235 / 470M, Empty: 32M, Relocated: 40M, In-Place: 0
-[32.193s][info][gc,reloc    ] GC(2) Medium Pages: 2 / 64M, Empty: 0M, Relocated: 3M, In-Place: 0
-[32.193s][info][gc,reloc    ] GC(2) Large Pages: 3 / 24M, Empty: 8M, Relocated: 0M, In-Place: 0
-[32.193s][info][gc,reloc    ] GC(2) Forwarding Usage: 13M
-[32.193s][info][gc,heap     ] GC(2) Min Capacity: 8M(0%)
-[32.193s][info][gc,heap     ] GC(2) Max Capacity: 28686M(100%)
-[32.193s][info][gc,heap     ] GC(2) Soft Max Capacity: 28686M(100%)
-[32.193s][info][gc,heap     ] GC(2)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low
-[32.193s][info][gc,heap     ] GC(2)  Capacity:     1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)         1794M (6%)
-[32.193s][info][gc,heap     ] GC(2)      Free:    28128M (98%)       28110M (98%)       28148M (98%)       28560M (100%)      28560M (100%)      28108M (98%)
-[32.193s][info][gc,heap     ] GC(2)      Used:      558M (2%)          576M (2%)          538M (2%)          126M (0%)          578M (2%)          126M (0%)
-[32.193s][info][gc,heap     ] GC(2)      Live:         -                71M (0%)           71M (0%)           71M (0%)             -                  -
-[32.193s][info][gc,heap     ] GC(2) Allocated:         -                18M (0%)           20M (0%)           18M (0%)             -                  -
-[32.193s][info][gc,heap     ] GC(2)   Garbage:         -               486M (2%)          446M (2%)           35M (0%)             -                  -
-[32.193s][info][gc,heap     ] GC(2) Reclaimed:         -                  -                40M (0%)          450M (2%)             -                  -
-[32.193s][info][gc          ] GC(2) Garbage Collection (Metadata GC Threshold) 558M(2%)->126M(0%)
-*/

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCGarbageSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCGarbageSummary.java
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCGarbageSummary {
+    private final long markEnd;
+    private final long relocateStart;
+    private final long relocateEnd;
+
+    public ZGCGarbageSummary(long markEnd, long relocateStart, long relocateEnd) {
+        this.markEnd = markEnd;
+        this.relocateStart = relocateStart;
+        this.relocateEnd = relocateEnd;
+    }
+
+    public long getMarkEnd() {
+        return markEnd;
+    }
+
+    public long getRelocateStart() {
+        return relocateStart;
+    }
+
+    public long getRelocateEnd() {
+        return relocateEnd;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCLiveSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCLiveSummary.java
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCLiveSummary {
+    private final long markEnd;
+    private final long relocateStart;
+    private final long relocateEnd;
+
+    public ZGCLiveSummary(long markEnd, long relocateStart, long relocateEnd) {
+        this.markEnd = markEnd;
+        this.relocateStart = relocateStart;
+        this.relocateEnd = relocateEnd;
+    }
+
+    public long getMarkEnd() {
+        return markEnd;
+    }
+
+    public long getRelocateStart() {
+        return relocateStart;
+    }
+
+    public long getRelocateEnd() {
+        return relocateEnd;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMarkSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMarkSummary.java
@@ -1,0 +1,37 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCMarkSummary {
+    private final int stripes;
+    private final int proactiveFlushes;
+    private final int terminatedFlushes;
+    private final int completions;
+    private final int continuations;
+    
+    public ZGCMarkSummary(int stripes, int proactiveFlushes, int terminatedFlushes, int completions, int continuations) {
+        this.stripes = stripes;
+        this.proactiveFlushes = proactiveFlushes;
+        this.terminatedFlushes = terminatedFlushes;
+        this.completions = completions;
+        this.continuations = continuations;
+    }
+    
+    public int getContinuations() {
+        return continuations;
+    }
+
+    public int getCompletions() {
+        return completions;
+    }
+
+    public int getTerminatedFlushes() {
+        return terminatedFlushes;
+    }
+
+    public int getProactiveFlushes() {
+        return proactiveFlushes;
+    }
+
+    public int getStripes() {
+        return stripes;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMemorySummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCMemorySummary.java
@@ -1,0 +1,20 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCMemorySummary {
+    private final long start;
+    private final long end;
+
+    public ZGCMemorySummary(long start, long end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public long getStart() {
+        return start;
+    }
+
+    public long getEnd() {
+        return end;
+    }
+
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCPhase.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCPhase.java
@@ -1,0 +1,27 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public enum ZGCPhase {
+    FULL(""),
+    MAJOR_YOUNG("Y"),
+    MAJOR_OLD("O"),
+    MINOR_YOUNG("y");
+
+    private final String phase;
+
+    ZGCPhase(String s) {
+        this.phase = s;
+    }
+
+    public String getPhase() {
+        return phase;
+    }
+
+    public static ZGCPhase get(String label) {
+        for (ZGCPhase zgcPhase : ZGCPhase.values()) {
+            if (zgcPhase.getPhase().equals(label.trim())) {
+                return zgcPhase;
+            }
+        }
+        throw new IllegalArgumentException("No matching ZGCPhase found for: " + label);
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCPromotedSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCPromotedSummary.java
@@ -1,0 +1,20 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCPromotedSummary {
+    private final long relocateStart;
+    private final long relocateEnd;
+
+    public ZGCPromotedSummary(long relocateStart, long relocateEnd) {
+
+        this.relocateStart = relocateStart;
+        this.relocateEnd = relocateEnd;
+    }
+
+    public long getRelocateEnd() {
+        return relocateEnd;
+    }
+
+    public long getRelocateStart() {
+        return relocateStart;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCReclaimSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCReclaimSummary.java
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 package com.microsoft.gctoolkit.event.zgc;
 
-public class ReclaimSummary {
+public class ZGCReclaimSummary {
 
     private final long reclaimStart;
     private final long reclaimEnd;
 
-    public ReclaimSummary(long reclaimStart, long reclaimEnd) {
+    public ZGCReclaimSummary(long reclaimStart, long reclaimEnd) {
         this.reclaimStart = reclaimStart;
         this.reclaimEnd = reclaimEnd;
     }
@@ -20,11 +20,11 @@ public class ReclaimSummary {
         return reclaimEnd;
     }
 
-    public ReclaimSummary sum(ReclaimSummary other) {
+    public ZGCReclaimSummary sum(ZGCReclaimSummary other) {
         if (other == null) {
             return this;
         }
-        return new ReclaimSummary(reclaimStart + other.reclaimStart, reclaimEnd + other.reclaimEnd);
+        return new ZGCReclaimSummary(reclaimStart + other.reclaimStart, reclaimEnd + other.reclaimEnd);
     }
 
 }

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCReferenceSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCReferenceSummary.java
@@ -1,0 +1,24 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCReferenceSummary {
+    private final long encountered;
+    private final long discovered;
+    private final long enqueued;
+
+    public ZGCReferenceSummary(long encountered, long discovered, long enqueued) {
+        this.encountered = encountered;
+        this.discovered = discovered;
+        this.enqueued = enqueued;
+    }
+    public long getEncountered() {
+        return encountered;
+    }
+
+    public long getDiscovered() {
+        return discovered;
+    }
+
+    public long getEnqueued() {
+        return enqueued;
+    }
+}

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogTrace.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogTrace.java
@@ -10,10 +10,14 @@ import com.microsoft.gctoolkit.event.UnifiedCountSummary;
 import com.microsoft.gctoolkit.event.UnifiedStatisticalSummary;
 import com.microsoft.gctoolkit.event.jvm.MetaspaceRecord;
 import com.microsoft.gctoolkit.event.jvm.PermGenSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCCollectionType;
+import com.microsoft.gctoolkit.event.zgc.ZGCPhase;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
+
+import static com.microsoft.gctoolkit.event.zgc.ZGCPhase.FULL;
 
 /**
  * Class that represents a chunk of GC log that we are attempting to match to a
@@ -82,6 +86,15 @@ public class GCLogTrace extends AbstractLogTrace {
      * @return The capture group parsed to a double.
      */
     public double getMilliseconds(int index) {
+        return getDoubleGroup(index);
+    }
+
+    /**
+     * Annoyingly we're assuming the field actually is s instead of confirming
+     * @param index Index of the capture group.
+     * @return The capture group parsed to a double.
+     */
+    public double getSeconds(int index) {
         return getDoubleGroup(index);
     }
 
@@ -288,5 +301,14 @@ public class GCLogTrace extends AbstractLogTrace {
         }
         System.out.println("-----------------------------------------");
         //}
+    }
+
+    public ZGCPhase getZCollectionPhase() {
+        String phase = getGroup(1);
+        if (phase == null) {
+            return FULL;
+        } else {
+            return ZGCPhase.get(phase);
+        }
     }
 }

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GenericTokens.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GenericTokens.java
@@ -20,6 +20,7 @@ public interface GenericTokens {
     //Time
     String TIME = "(-?" + REAL_NUMBER + ")";
     String DURATION_MS = TIME + "\\s?ms";
+    String DURATION_S = TIME + "\\s?s";
     String INT_DURATION_MS = INTEGER + "ms";
     //0.0700188
     String PAUSE_TIME = TIME + "\\s?(?:secs?|ms)";

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
@@ -1,19 +1,32 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 package com.microsoft.gctoolkit.parser;
-
 import com.microsoft.gctoolkit.GCToolKit;
+
 import com.microsoft.gctoolkit.aggregator.EventSource;
 import com.microsoft.gctoolkit.event.GCCause;
+import com.microsoft.gctoolkit.event.GCEvent;
 import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.event.jvm.JVMEvent;
 import com.microsoft.gctoolkit.event.jvm.JVMTermination;
-import com.microsoft.gctoolkit.event.zgc.OccupancySummary;
-import com.microsoft.gctoolkit.event.zgc.ReclaimSummary;
-import com.microsoft.gctoolkit.event.zgc.MajorZGCCycle;
 import com.microsoft.gctoolkit.event.zgc.MinorZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.ZGCAllocatedSummary;
+import com.microsoft.gctoolkit.event.zgc.FullZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.ZGCGarbageSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCLiveSummary;
+import com.microsoft.gctoolkit.event.zgc.MajorZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.OccupancySummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCCompactedSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCPhase;
+import com.microsoft.gctoolkit.event.zgc.ZGCPromotedSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCReclaimSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCCollectionType;
+import com.microsoft.gctoolkit.event.zgc.ZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.ZGCMarkSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCMemoryPoolSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCMetaspaceSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCMemorySummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCReferenceSummary;
 import com.microsoft.gctoolkit.jvm.Diary;
 import com.microsoft.gctoolkit.message.ChannelName;
 import com.microsoft.gctoolkit.message.JVMEventChannel;
@@ -39,12 +52,14 @@ import java.util.logging.Logger;
  * CMS failures
  * System.gc() calls
  */
-
 public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
 
     private static final Logger LOGGER = Logger.getLogger(ZGCParser.class.getName());
 
-    private ZGCForwardReference forwardReference;
+    private final boolean debugging = Boolean.getBoolean("microsoft.debug");
+    private final boolean develop = Boolean.getBoolean("microsoft.develop");
+
+    private ZFwdRef forwardReference;
 
     private final long[] markStart = new long[3];
     private final long[] markEnd = new long[3];
@@ -52,6 +67,8 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     private final long[] relocateEnd = new long[3];
 
     private final MRUQueue<GCParseRule, BiConsumer<GCLogTrace, String>> parseRules;
+    private boolean oldGenHeapStats = false;
+    private boolean youngGenHeapStats = false;
 
     //Implement all capture methods
     {
@@ -60,7 +77,6 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         parseRules.put(PAUSE_PHASE, this::pausePhase);
         parseRules.put(CONCURRENT_PHASE, this::concurrentPhase);
         parseRules.put(LOAD, this::load);
-        parseRules.put(GENERATION_LOAD, this::load);
         parseRules.put(MMU, this::mmu);
         parseRules.put(MARK_SUMMARY, this::markSummary);
         parseRules.put(RELOCATION_SUMMARY, this::relocationSummary);
@@ -68,14 +84,22 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         parseRules.put(METASPACE, this::metaspace);
         parseRules.put(REFERENCE_PROCESSING, this::referenceProcessing);
         parseRules.put(CAPACITY, this::capacity);
-        parseRules.put(GENERATIONAL_MEMORY_STATISTICS, this::memoryStatistics);
         parseRules.put(MEMORY_TABLE_ENTRY_SIZE, this::sizeEntry);
         parseRules.put(MEMORY_TABLE_ENTRY_OCCUPANCY, this::occupancyEntry);
-        parseRules.put(MEMORY_TABLE_ENTRY_RECLAIMED, this::reclaimed);
         parseRules.put(MEMORY_SUMMARY, this::memorySummary);
         parseRules.put(END_OF_FILE, this::endOfFile);
-    }
+        parseRules.put(MEMORY_TABLE_ENTRY_RECLAIMED_PROMOTED, this::reclaimedPromoted);
+        parseRules.put(MEMORY_TABLE_ENTRY_COMPACTED, this::compacted);
 
+        // Generation ("gen") ZGC only options
+        parseRules.put(LOAD_GEN, this::loadGen);
+        parseRules.put(REFERENCE_PROCESSING_GEN, this::referenceProcessingGen);
+        parseRules.put(END_OF_PHASE_SUMMARY_GEN, this::endOfPhaseMemorySummary);
+
+        // Phase change rules
+        parseRules.put(MARK_OLD_GEN_HEAP_STATS, this::markOldGenHeapStats);
+        parseRules.put(MARK_YOUNG_GEN_HEAP_STATS, this::markYoungGenHeapStats);
+    }
 
     public ZGCParser() {}
 
@@ -83,6 +107,25 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     public Set<EventSource> eventsProduced() {
         return Set.of(EventSource.ZGC);
     }
+
+    /**
+     * This marks the phase we're in for memory stats. Generation ZGC will provide heap capacity
+     * as well as old and young gen capacities. This enables the Young gen phase
+     */
+    private void markYoungGenHeapStats(GCLogTrace gcLogTrace, String s) {
+        this.youngGenHeapStats = true;
+        this.oldGenHeapStats = false;
+    }
+
+    /**
+     * This marks the phase we're in for memory stats. Generation ZGC will provide heap capacity
+     * as well as old and young gen capacities. This enables the Old gen phase
+     */
+    private void markOldGenHeapStats(GCLogTrace gcLogTrace, String s) {
+        this.youngGenHeapStats = false;
+        this.oldGenHeapStats = true;
+    }
+
 
     @Override
     public String getName() {
@@ -120,71 +163,152 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         publish(new JVMTermination(getClock(), diary.getTimeOfFirstEvent()));
     }
 
+    private ZGCForwardReference getForwardRefForPhase(ZGCPhase zgcPhase) {
+        switch (zgcPhase) {
+            // No phase information, legacy ZGC
+            case FULL:
+                return (ZGCForwardReference) forwardReference;
+            case MAJOR_YOUNG:
+                return ((ZGCMajorForwardReference)forwardReference).getYoungGeneration();
+            case MAJOR_OLD:
+                return ((ZGCMajorForwardReference)forwardReference).getOldGeneration();
+            case MINOR_YOUNG:
+                return ((ZGCMinorForwardReference)forwardReference).getYoungGeneration();
+        }
+
+        // Should never reach (should convert to switch expression)
+        throw new RuntimeException("Unknown phase " + zgcPhase);
+    }
+
     private void cycleStart(GCLogTrace trace, String s) {
-        forwardReference = new ZGCForwardReference(getClock(), trace.getLongGroup(1), trace.gcCause(1, 1));
+        ZGCCollectionType type = ZGCCollectionType.get(trace.getGroup(2));
+
+        switch (type) {
+            case FULL:
+                // FULL, Legacy ZGC
+                forwardReference = new ZGCForwardReference(getClock(), trace.getLongGroup(1), trace.gcCause(3,0), type, ZGCPhase.FULL);
+                break;
+            case MINOR:
+                // MINOR, young only collection
+                forwardReference = new ZGCMinorForwardReference(getClock(), trace.getLongGroup(1), trace.gcCause(3,0), type);
+                break;
+            case MAJOR:
+                // MAJOR, young and old gen collection
+                forwardReference = new ZGCMajorForwardReference(getClock(), trace.getLongGroup(1), trace.gcCause(3,0), type);
+                break;
+        }
     }
 
     private void pausePhase(GCLogTrace trace, String s) {
-        DateTimeStamp startTime = getClock().minus(Math.round(trace.getDuration()) / 1000.00d);
-        if ("Mark Start".equals(trace.getGroup(1))) {
-            forwardReference.setPauseMarkStartDuration(trace.getDuration());
-            forwardReference.setPauseMarkStart(startTime);
-        } else if ("Mark End".equals(trace.getGroup(1))) {
-            forwardReference.setPauseMarkEndDuration(trace.getDuration());
-            forwardReference.setPauseMarkEndStart(startTime);
-        } else if ("Relocate Start".equals(trace.getGroup(1))) {
-            forwardReference.setPauseRelocateStartDuration(trace.getDuration());
-            forwardReference.setPauseRelocateStart(startTime);
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        DateTimeStamp startTime = getClock().minus(trace.getDuration() / 1000.00d);
+        if ("Mark Start".equals(trace.getGroup(2))) {
+            ref.setPauseMarkStartDuration(trace.getDuration());
+            ref.setPauseMarkStart(startTime);
+        } if ("Mark Start (Major)".equals(trace.getGroup(2))) {
+            ref.setPauseMarkStartDuration(trace.getDuration());
+            ref.setPauseMarkStart(startTime);
+        } else if ("Mark End".equals(trace.getGroup(2))) {
+            ref.setPauseMarkEndDuration(trace.getDuration());
+            ref.setPauseMarkEndStart(startTime);
+        } else if ("Relocate Start".equals(trace.getGroup(2))) {
+            ref.setPauseRelocateStartDuration(trace.getDuration());
+            ref.setPauseRelocateStart(startTime);
         } else
             trace.notYetImplemented();
     }
 
     private void concurrentPhase(GCLogTrace trace, String s) {
-        DateTimeStamp startTime = getClock().minus(Math.round(trace.getDuration()) / 1000.0d);
-        if ("Mark".equals(trace.getGroup(1))) {
-            forwardReference.setConcurrentMarkDuration(trace.getDuration());
-            forwardReference.setConcurrentMarkStart(startTime);
-        } else if ("Mark Free".equals(trace.getGroup(1))) {
-            forwardReference.setConcurrentMarkFreeDuration(trace.getDuration());
-            forwardReference.setConcurrentMarkFreeStart(startTime);
-        } else if ("Process Non-Strong References".equals(trace.getGroup(1))
-                || "Process Non-Strong".equals(trace.getGroup(1))) {
-            forwardReference.setConcurrentProcessNonStrongReferencesDuration(trace.getDuration());
-            forwardReference.setConcurrentProcessNonStringReferencesStart(startTime);
-        } else if ("Reset Relocation Set".equals(trace.getGroup(1))) {
-            forwardReference.setConcurrentResetRelocationSetDuration(trace.getDuration());
-            forwardReference.setConcurrentResetRelocationSetStart(startTime);
-        } else if ("Select Relocation Set".equals(trace.getGroup(1))) {
-            forwardReference.setConcurrentSelectRelocationSetDuration(trace.getDuration());
-            forwardReference.setConcurrentSelectRelocationSetStart(startTime);
-        } else if ("Relocate".equals(trace.getGroup(1))) {
-            forwardReference.setConcurrentSelectRelocateStart(startTime);
-            forwardReference.setConcurrentSelectRelocateDuration(trace.getDuration());
-        } else
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        DateTimeStamp startTime = getClock().minus(trace.getDuration() / 1000.0d);
+        if ("Mark".equals(trace.getGroup(2))) {
+            ref.setConcurrentMarkDuration(trace.getDuration());
+            ref.setConcurrentMarkStart(startTime);
+        } else if ("Mark Continue".equals(trace.getGroup(2))) {
+            ref.setConcurrentMarkContinueDuration(trace.getDuration());
+            ref.setConcurrentMarkContinueStart(startTime);
+        } else if ("Mark Free".equals(trace.getGroup(2))) {
+            ref.setConcurrentMarkFreeDuration(trace.getDuration());
+            ref.setConcurrentMarkFreeStart(startTime);
+        } else if ("Process Non-Strong References".equals(trace.getGroup(2)) || "Process Non-Strong".equals(trace.getGroup(2)) ) {
+            ref.setConcurrentProcessNonStrongReferencesDuration(trace.getDuration());
+            ref.setConcurrentProcessNonStringReferencesStart(startTime);
+        } else if ("Reset Relocation Set".equals(trace.getGroup(2))) {
+            ref.setConcurrentResetRelocationSetDuration(trace.getDuration());
+            ref.setConcurrentResetRelocationSetStart(startTime);
+        } else if ("Select Relocation Set".equals(trace.getGroup(2))) {
+            ref.setConcurrentSelectRelocationSetDuration(trace.getDuration());
+            ref.setConcurrentSelectRelocationSetStart(startTime);
+        } else if ("Relocate".equals(trace.getGroup(2))) {
+            ref.setConcurrentSelectRelocateStart(startTime);
+            ref.setConcurrentSelectRelocateDuration(trace.getDuration());
+        } else if ("Remap Roots".equals(trace.getGroup(2))) {
+            ref.setConcurrentRemapRootsStart(startTime);
+            ref.setConcurrentRemapRootsDuration(trace.getDuration());
+        } else if ("Mark Roots".equals(trace.getGroup(2))) {
+            ref.setMarkRootsStart(startTime);
+            ref.setMarkRootsDuration(trace.getDuration());
+        } else if ("Mark Follow".equals(trace.getGroup(2))) {
+            ref.setMarkFollowStart(startTime);
+            ref.setMarkFollowDuration(trace.getDuration());
+        } else if ("Remap Roots Colored".equals(trace.getGroup(2))) {
+            ref.setRemapRootsColoredStart(startTime);
+            ref.setRemapRootsColoredDuration(trace.getDuration());
+        } else if ("Remap Roots Uncolored".equals(trace.getGroup(2))) {
+            ref.setRemapRootsUncoloredStart(startTime);
+            ref.setRemapRootsUncoloredDuration(trace.getDuration());
+        } else if ("Remap Remembered".equals(trace.getGroup(2))) {
+            ref.setRemapRememberedStart(startTime);
+            ref.setRemapRememberedDuration(trace.getDuration());
+        }
+        else
             trace.notYetImplemented();
     }
 
     private void load(GCLogTrace trace, String s) {
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
         double[] load = new double[3];
-        load[0] = trace.getDoubleGroup(1);
-        load[1] = trace.getDoubleGroup(2);
-        load[2] = trace.getDoubleGroup(3);
-        forwardReference.setLoad(load);
+        load[0] = trace.getDoubleGroup(2);
+        load[1] = trace.getDoubleGroup(3);
+        load[2] = trace.getDoubleGroup(4);
+        ref.setLoad(load);
+    }
+
+    private void loadGen(GCLogTrace trace, String s) {
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        double[] load = new double[3];
+        load[0] = trace.getDoubleGroup(2);
+        load[1] = trace.getDoubleGroup(3);
+        load[2] = trace.getDoubleGroup(4);
+        ref.setLoad(load);
     }
 
     private void mmu(GCLogTrace trace, String s) {
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
         double[] mmu = new double[6];
-        mmu[0] = trace.getDoubleGroup(1);
-        mmu[1] = trace.getDoubleGroup(2);
-        mmu[2] = trace.getDoubleGroup(3);
-        mmu[3] = trace.getDoubleGroup(4);
-        mmu[4] = trace.getDoubleGroup(5);
-        mmu[5] = trace.getDoubleGroup(6);
-        forwardReference.setMMU(mmu);
+        mmu[0] = trace.getDoubleGroup(2);
+        mmu[1] = trace.getDoubleGroup(3);
+        mmu[2] = trace.getDoubleGroup(4);
+        mmu[3] = trace.getDoubleGroup(5);
+        mmu[4] = trace.getDoubleGroup(6);
+        mmu[5] = trace.getDoubleGroup(7);
+        ref.setMMU(mmu);
     }
 
     private void markSummary(GCLogTrace trace, String s) {
-        //trace.notYetImplemented();
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        ref.setMarkSummary(new ZGCMarkSummary(
+                trace.getIntegerGroup(2),
+                trace.getIntegerGroup(3),
+                trace.getIntegerGroup(4),
+                trace.getIntegerGroup(5),
+                trace.getIntegerGroup(6)));
     }
 
     private void relocationSummary(GCLogTrace trace, String s) {
@@ -196,15 +320,32 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     }
 
     private void metaspace(GCLogTrace trace, String s) {
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
         ZGCMetaspaceSummary summary = new ZGCMetaspaceSummary(
-                trace.toKBytes(1),
-                trace.toKBytes(3),
-                trace.toKBytes(5));
-        forwardReference.setMetaspace(summary);
+                trace.toKBytes(2),
+                trace.toKBytes(4),
+                trace.toKBytes(6));
+        ref.setMetaspaceSummary(summary);
     }
 
     private void referenceProcessing(GCLogTrace trace, String s) {
         //trace.notYetImplemented();
+    }
+
+    private void referenceProcessingGen(GCLogTrace trace, String s) {
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        ZGCReferenceSummary summary = new ZGCReferenceSummary(trace.getLongGroup(3), trace.getLongGroup(4), trace.getLongGroup(5));
+        if ("Soft".equals(trace.getGroup(2))){
+            ref.setSoftRefSummary(summary);
+        } else if ("Weak".equals(trace.getGroup(2))) {
+            ref.setWeakRefSummary(summary);
+        } else if ("Final".equals(trace.getGroup(2))) {
+            ref.setFinalRefSummary(summary);
+        } else if ("Phantom".equals(trace.getGroup(2))) {
+            ref.setPhantomRefSummary(summary);
+        }
     }
 
     private void capacity(GCLogTrace trace, String s) {
@@ -212,27 +353,32 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     }
 
     private void captureAtIndex(GCLogTrace trace, int index) {
-        markStart[index] = trace.toKBytes(2);
-        markEnd[index] = trace.toKBytes(5);
-        relocateStart[index] = trace.toKBytes(8);
-        relocateEnd[index] = trace.toKBytes(11);
-    }
-
-    private void memoryStatistics(GCLogTrace trace, String s) {
-        switch (trace.getGroup(1)) {
-            case "Young Generation":
-                forwardReference.setMemoryScope(ZGCMemoryScope.YOUNG_GENERATION);
-                break;
-            case "Old Generation":
-                forwardReference.setMemoryScope(ZGCMemoryScope.OLD_GENERATION);
-                break;
-            default:
-                forwardReference.setMemoryScope(ZGCMemoryScope.ALL);
-        }
+        // temporary holder of marking info to get set on fwdref
+        markStart[index] = trace.toKBytes(3);
+        markEnd[index] = trace.toKBytes(6);
+        relocateStart[index] = trace.toKBytes(9);
+        relocateEnd[index] = trace.toKBytes(12);
     }
 
     private void sizeEntry(GCLogTrace trace, String s) {
-        switch (trace.getGroup(1)) {
+        ZGCPhase phase = trace.getZCollectionPhase();
+        ZGCForwardReference ref = getForwardRefForPhase(phase);
+
+        if (oldGenHeapStats || youngGenHeapStats) {
+            if ("Used".equals(trace.getGroup(2))){
+                OccupancySummary summary = new OccupancySummary(
+                        trace.toKBytes(3),
+                        trace.toKBytes(6),
+                        trace.toKBytes(9),
+                        trace.toKBytes(12));
+                ref.setUsed(phase, summary);
+            } else {
+                trace.notYetImplemented();
+            }
+            return;
+        }
+
+        switch (trace.getGroup(2)) {
             case "Capacity":
                 captureAtIndex(trace, 0);
                 break;
@@ -240,55 +386,117 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
                 captureAtIndex(trace, 1);
                 break;
             case "Used":
-                captureAtIndex(trace, 2);
-                forwardReference.setMarkStart(new ZGCMemoryPoolSummary(markStart[0], markStart[1], markStart[2]));
-                forwardReference.setMarkEnd(new ZGCMemoryPoolSummary(markEnd[0], markEnd[1], markEnd[2]));
-                forwardReference.setRelocateStart(new ZGCMemoryPoolSummary(relocateStart[0], relocateStart[1], relocateStart[2]));
-                forwardReference.setRelocateEnd(new ZGCMemoryPoolSummary(relocateEnd[0], relocateEnd[1], relocateEnd[2]));
+                ref.setMarkStart(new ZGCMemoryPoolSummary(markStart[0], markStart[1], trace.toKBytes(3)));
+                ref.setMarkEnd(new ZGCMemoryPoolSummary(markEnd[0], markEnd[1], trace.toKBytes(6)));
+                ref.setRelocateStart(new ZGCMemoryPoolSummary(relocateStart[0], relocateStart[1], trace.toKBytes(9)));
+                ref.setRelocateEnd(new ZGCMemoryPoolSummary(relocateEnd[0], relocateEnd[1], trace.toKBytes(12)));
                 break;
             default:
-                LOGGER.warning(trace.getGroup(1) + "not recognized, Heap Occupancy/size is is ignored. Please report this with the GC log");
+                LOGGER.warning(trace.getGroup(2) + "not recognized, Heap Occupancy/size is is ignored. Please report this with the GC log");
         }
     }
 
     private void occupancyEntry(GCLogTrace trace, String s) {
-        OccupancySummary summary = new OccupancySummary(
-                trace.toKBytes(2),
-                trace.toKBytes(5),
-                trace.toKBytes(8));
-        if ("Live".equals(trace.getGroup(1))) {
-            forwardReference.setMarkedLive(summary);
-        } else if ("Allocated".equals(trace.getGroup(1))) {
-            forwardReference.setAllocated(summary);
-        } else if ("Garbage".equals(trace.getGroup(1))) {
-            forwardReference.setGarbage(summary);
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        if ("Live".equals(trace.getGroup(2))) {
+            ref.setMarkedLiveSummary(new ZGCLiveSummary(
+                    trace.toKBytes(3),
+                    trace.toKBytes(6),
+                    trace.toKBytes(9)));
+        } else if ("Allocated".equals(trace.getGroup(2))) {
+            ref.setAllocatedSummary(new ZGCAllocatedSummary(
+                    trace.toKBytes(3),
+                    trace.toKBytes(6),
+                    trace.toKBytes(9)));
+        } else if ("Garbage".equals(trace.getGroup(2))) {
+            ref.setGarbageSummary(new ZGCGarbageSummary(
+                    trace.toKBytes(3),
+                    trace.toKBytes(6),
+                    trace.toKBytes(9)));
         } else
             trace.notYetImplemented();
     }
 
-    private void reclaimed(GCLogTrace trace, String s) {
-        forwardReference.setReclaimed(
-                new ReclaimSummary(
-                        trace.toKBytes(1),
-                        trace.toKBytes(4)
+    private void reclaimedPromoted(GCLogTrace trace, String s) {
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        if ("Reclaimed".equals(trace.getGroup(2))) {
+            ref.setReclaimSummary(
+                    new ZGCReclaimSummary(
+                            trace.toKBytes(3),
+                            trace.toKBytes(6)
+                    )
+            );
+        } else if ("Promoted".equals(trace.getGroup(2))) {
+            ref.setPromotedSummary(
+                    new ZGCPromotedSummary(
+                            trace.toKBytes(3),
+                            trace.toKBytes(6)
+                    )
+            );
+        }
+    }
+
+    private void compacted(GCLogTrace trace, String s) {
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        // Exit both young and old gen stats, reset for next cycle
+        this.oldGenHeapStats = false;
+        this.youngGenHeapStats = false;
+        ref.setCompactedSummary(
+                new ZGCCompactedSummary(
+                        trace.toKBytes(2)
                 )
         );
+    }
+
+    private void endOfPhaseMemorySummary(GCLogTrace trace, String s) {
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        ref.setMemorySummary(
+                new ZGCMemorySummary(
+                        trace.toKBytes(3),
+                        trace.toKBytes(6)));
+
+        if (trace.getGroup(9) != null) {
+            ref.setGcDuration(trace.getSeconds(9));
+        }
     }
 
     private void memorySummary(GCLogTrace trace, String s) {
-        forwardReference.setMemorySummary(
-                new ReclaimSummary(
-                        trace.toKBytes(2),
-                        trace.toKBytes(5)
-                )
-        );
+        ZGCCollectionType type = ZGCCollectionType.get(trace.getGroup(1));
+        switch (type) {
+            case FULL:
+                ((ZGCForwardReference)forwardReference).setMemorySummary(
+                    new ZGCMemorySummary(
+                            trace.toKBytes(3),
+                            trace.toKBytes(6)));
+                break;
+            case MINOR:
+                ((ZGCMinorForwardReference)forwardReference).setMemorySummary(
+                        new ZGCMemorySummary(
+                                trace.toKBytes(3),
+                                trace.toKBytes(6)));
+                break;
+            case MAJOR:
+                ((ZGCMajorForwardReference)forwardReference).setMemorySummary(
+                        new ZGCMemorySummary(
+                                trace.toKBytes(3),
+                                trace.toKBytes(6)));
+                break;
+        }
+
+        // TODO: Consider using logging cycle duration instead of timestamps
+
         publish();
     }
 
+
     private void log(String line) {
         GCToolKit.LOG_DEBUG_MESSAGE(() -> "ZGCHeapParser missed: " + line);
-        LOGGER.log(Level.WARNING, "Missed: {0}", line);
 
+        LOGGER.log(Level.WARNING, "Missed: {0}", line);
     }
 
     public void logMissedFirstRecordForEvent(String line) {
@@ -296,7 +504,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     }
 
     public void publish() {
-        publish(forwardReference.toZGCCycle(getClock()));
+        publish(forwardReference.getGCEVent(getClock()));
     }
 
     public void publish(JVMEvent event) {
@@ -304,9 +512,124 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         forwardReference = null;
     }
 
-    private class ZGCForwardReference {
+    private interface ZFwdRef {
+        GCEvent getGCEVent(DateTimeStamp endTime);
+    }
+
+    private static class ZGCMinorForwardReference implements ZFwdRef {
         private final DateTimeStamp startTimeStamp;
         private final GCCause gcCause;
+        private final ZGCCollectionType type;
+        private final long gcId;
+        private ZGCMemorySummary cycleMemorySummary;
+
+        // Holds single reference to minor collection stats
+        private ZGCForwardReference youngGeneration;
+
+        public ZGCMinorForwardReference(DateTimeStamp dateTimeStamp, long gcId, GCCause cause, ZGCCollectionType type) {
+            this.startTimeStamp = dateTimeStamp;
+            this.gcCause = cause;
+            this.type = type;
+            this.gcId = gcId;
+
+            youngGeneration = new ZGCForwardReference(dateTimeStamp, gcId, cause, type, ZGCPhase.MINOR_YOUNG);
+        }
+
+        public ZGCForwardReference getYoungGeneration() {
+            return youngGeneration;
+        }
+
+        @Override
+        public GCEvent getGCEVent(DateTimeStamp endTime) {
+            GarbageCollectionTypes gcType = GarbageCollectionTypes.Unknown;
+            switch (type) {
+                case FULL:
+                    gcType = GarbageCollectionTypes.ZGCFull;
+                    break;
+                case MINOR:
+                    gcType = GarbageCollectionTypes.ZGCMinor;
+                    break;
+                case MAJOR:
+                    gcType = GarbageCollectionTypes.ZGCMajor;
+                    break;
+            }
+
+            MinorZGCCycle cycle = new MinorZGCCycle(startTimeStamp, gcType, gcCause, endTime.minus(startTimeStamp));
+            cycle.setYoungCycle(youngGeneration.getZGCCycle(endTime));
+            cycle.setMemorySummary(cycleMemorySummary);
+            cycle.setGcId(gcId);
+
+            return cycle;
+        }
+
+        public void setMemorySummary(ZGCMemorySummary cycleMemorySummary) {
+            this.cycleMemorySummary = cycleMemorySummary;
+        }
+    }
+
+    private static class ZGCMajorForwardReference implements ZFwdRef {
+        private final DateTimeStamp startTimeStamp;
+        private final GCCause gcCause;
+        private final ZGCCollectionType type;
+        private final long gcId;
+        private ZGCMemorySummary cycleMemorySummary;
+
+        // Holds two references to minor and major collection stats
+        private final ZGCForwardReference youngGeneration;
+        private final ZGCForwardReference oldGeneration;
+
+        public ZGCMajorForwardReference(DateTimeStamp dateTimeStamp, long gcId, GCCause cause, ZGCCollectionType type) {
+            this.startTimeStamp = dateTimeStamp;
+            this.gcCause = cause;
+            this.type = type;
+            this.gcId = gcId;
+
+            youngGeneration = new ZGCForwardReference(dateTimeStamp, gcId, cause, type, ZGCPhase.MAJOR_YOUNG);
+            oldGeneration = new ZGCForwardReference(dateTimeStamp, gcId, cause, type, ZGCPhase.MAJOR_OLD);
+        }
+
+        public ZGCForwardReference getYoungGeneration() {
+            return youngGeneration;
+        }
+
+        public ZGCForwardReference getOldGeneration() {
+            return oldGeneration;
+        }
+
+        public void setMemorySummary(ZGCMemorySummary cycleMemorySummary) {
+            this.cycleMemorySummary = cycleMemorySummary;
+        }
+
+        @Override
+        public GCEvent getGCEVent(DateTimeStamp endTime) {
+            GarbageCollectionTypes gcType = GarbageCollectionTypes.Unknown;
+            switch (type) {
+                case FULL:
+                    gcType = GarbageCollectionTypes.ZGCFull;
+                    break;
+                case MINOR:
+                    gcType = GarbageCollectionTypes.ZGCMinor;
+                    break;
+                case MAJOR:
+                    gcType = GarbageCollectionTypes.ZGCMajor;
+                    break;
+            }
+
+            MajorZGCCycle cycle = new MajorZGCCycle(startTimeStamp, gcType, gcCause, endTime.minus(startTimeStamp));
+            cycle.setYoungCycle(youngGeneration.getZGCCycle(endTime));
+            cycle.setOldCycle(oldGeneration.getZGCCycle(endTime));
+            cycle.setMemorySummary(cycleMemorySummary);
+            cycle.setGcId(gcId);
+
+            return cycle;
+        }
+    }
+
+    private static class ZGCForwardReference implements ZFwdRef {
+        private final DateTimeStamp startTimeStamp;
+        private final GCCause gcCause;
+        private final ZGCCollectionType type;
+        private final ZGCPhase phase;
         private final long gcId;
 
         // Timing
@@ -329,225 +652,240 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         private double concurrentSelectRelocationSetDuration;
         private DateTimeStamp concurrentSelectRelocateStart;
         private double concurrentSelectRelocateDuration;
+        private DateTimeStamp concurrentMarkContinueStart;
+        private double concurrentMarkContinueDuration;
+
 
         // Memory
         private ZGCMemoryPoolSummary markStart;
         private ZGCMemoryPoolSummary markEnd;
         private ZGCMemoryPoolSummary relocatedStart;
         private ZGCMemoryPoolSummary relocateEnd;
-        private OccupancySummary markedLive;
-        private OccupancySummary allocated;
-        private OccupancySummary garbage;
-        private ReclaimSummary reclaimed;
-        private ReclaimSummary memorySummary;
-        private ZGCMetaspaceSummary metaspace;
-        private ZGCMemoryScope memoryScope = ZGCMemoryScope.ALL;
+        private ZGCLiveSummary liveSummary;
+        private ZGCAllocatedSummary allocatedSummary;
+        private ZGCGarbageSummary garbageSummary;
+        private ZGCReclaimSummary reclaimSummary;
+        private ZGCMemorySummary memorySummary;
+        private ZGCMetaspaceSummary metaspaceSummary;
+        private ZGCMarkSummary markSummary;
 
         //Load
         private double[] load = new double[3];
         private double[] mmu = new double[6];
+        private DateTimeStamp concurrentRemapRootsStart;
+        private double concurrentRemapRootsDuration;
+        private DateTimeStamp markRootsStart;
+        private double markRootsDuration;
+        private DateTimeStamp markFollowStart;
+        private double markFollowDuration;
+        private DateTimeStamp remapRootColoredStart;
+        private double remapRootsColoredDuration;
+        private DateTimeStamp remapRootsUncoloredStart;
+        private double remapRootsUncoloredDuration;
+        private DateTimeStamp remapRememberedStart;
+        private double remapRememberedDuration;
+        private ZGCPromotedSummary promotedSummary;
+        private ZGCCompactedSummary compactedSummary;
+        private Double gcDuration;
+        private OccupancySummary usedOccupancySummary;
+        private ZGCReferenceSummary softRefSummary;
+        private ZGCReferenceSummary weakRefSummary;
+        private ZGCReferenceSummary finalRefSummary;
+        private ZGCReferenceSummary phantomRefSummary;
 
-        public ZGCForwardReference(DateTimeStamp dateTimeStamp, long gcId, GCCause cause) {
+        public ZGCForwardReference(DateTimeStamp dateTimeStamp, long gcId, GCCause cause, ZGCCollectionType type, ZGCPhase phase) {
             this.startTimeStamp = dateTimeStamp;
             this.gcId = gcId;
-            gcCause = cause;
+            this.gcCause = cause;
+            this.type = type;
+            this.phase = phase;
         }
 
-        MajorZGCCycle toZGCCycle(DateTimeStamp endTime) {
+        @Override
+        public GCEvent getGCEVent(DateTimeStamp endTime) {
+            GarbageCollectionTypes gcType = GarbageCollectionTypes.Unknown;
+            switch (type) {
+                case FULL:
+                    gcType = GarbageCollectionTypes.ZGCFull;
+                    break;
+                case MINOR:
+                    gcType = GarbageCollectionTypes.ZGCMinor;
+                    break;
+                case MAJOR:
+                    gcType = GarbageCollectionTypes.ZGCMajor;
+                    break;
+            }
 
-            MajorZGCCycle cycle = null;
-            switch(forwardReference.memoryScope) {
-                case ALL:
-                    cycle = new MajorZGCCycle(startTimeStamp, GarbageCollectionTypes.ZGCCycle, gcCause, endTime.minus(startTimeStamp));
-                    break;
-                case YOUNG_GENERATION:
-                    cycle = new MinorZGCCycle(startTimeStamp, GarbageCollectionTypes.ZGCCycle, gcCause, endTime.minus(startTimeStamp));
-                    break;
-                case OLD_GENERATION:
-                    cycle = new MajorZGCCycle(startTimeStamp, GarbageCollectionTypes.ZGCCycle, gcCause, endTime.minus(startTimeStamp));
-                    break;
-                default:
-                    LOGGER.warning("Internal Error - Unknown memory scope: " + forwardReference.memoryScope);
-            };
+            // Duration recorded by GC
+            FullZGCCycle fullZGCCycle;
+            if (gcDuration != null){
+                fullZGCCycle = new FullZGCCycle(startTimeStamp, gcType, gcCause, gcDuration);
+            } else {
+                fullZGCCycle = new FullZGCCycle(startTimeStamp, gcType, gcCause, endTime.minus(startTimeStamp));
+            }
+
+            fullZGCCycle.setZGCCycle(getZGCCycle(endTime));
+
+            return fullZGCCycle;
+        }
+
+        public ZGCCycle getZGCCycle(DateTimeStamp endTime) {
+            ZGCCycle cycle = new ZGCCycle();
             cycle.setGcId(gcId);
+            cycle.setType(type);
+            cycle.setPhase(phase);
             cycle.setPauseMarkStart(pauseMarkStart, pauseMarkStartDuration);
             cycle.setConcurrentMark(concurrentMarkStart, concurrentMarkDuration);
+            cycle.setConcurrentMarkContinue(concurrentMarkContinueStart, concurrentMarkContinueDuration);
             cycle.setConcurrentMarkFree(concurrentMarkFreeStart, concurrentMarkFreeDuration);
             cycle.setPauseMarkEnd(pauseMarkEndStart, pauseMarkEndDuration);
+            cycle.setMarkRoots(markRootsStart, markRootsDuration);
+            cycle.setMarkFollow(markFollowStart, markFollowDuration);
+            cycle.setRemapRootsColored(remapRootColoredStart, remapRootsColoredDuration);
+            cycle.setRemapRootsUncolored(remapRootsUncoloredStart, remapRootsUncoloredDuration);
+            cycle.setRemapRemembered(remapRememberedStart, remapRememberedDuration);
             cycle.setConcurrentProcessNonStrongReferences(concurrentProcessNonStringReferencesStart, concurrentProcessNonStrongReferencesDuration);
             cycle.setConcurrentResetRelocationSet(concurrentResetRelocationSetStart, concurrentResetRelocationSetDuration);
             cycle.setConcurrentSelectRelocationSet(concurrentSelectRelocationSetStart, concurrentSelectRelocationSetDuration);
             cycle.setPauseRelocateStart(pauseRelocateStart, pauseRelocateStartDuration);
             cycle.setConcurrentRelocate(concurrentSelectRelocateStart, concurrentSelectRelocateDuration);
+            cycle.setConcurrentRemapRoots(concurrentRemapRootsStart, concurrentRemapRootsDuration);
+            cycle.setPromotedSummary(promotedSummary);
+            cycle.setCompactedSummary(compactedSummary);
+            cycle.setusedOccupancySummary(usedOccupancySummary);
+            cycle.setSoftRefSummary(softRefSummary);
+            cycle.setWeakRefSummary(weakRefSummary);
+            cycle.setFinalRefSummary(finalRefSummary);
+            cycle.setPhantomRefSummary(phantomRefSummary);
+
             //Memory
             cycle.setMarkStart(markStart);
             cycle.setMarkEnd(markEnd);
             cycle.setRelocateStart(relocatedStart);
             cycle.setRelocateEnd(relocateEnd);
-            cycle.setLive(markedLive);
-            cycle.setAllocated(allocated);
-            cycle.setGarbage(garbage);
-            cycle.setReclaimed(reclaimed);
+            cycle.setLiveSummary(liveSummary);
+            cycle.setAllocatedSummary(allocatedSummary);
+            cycle.setGarbageSummary(garbageSummary);
+            cycle.setReclaimSummary(reclaimSummary);
             cycle.setMemorySummary(memorySummary);
-            cycle.setMetaspace(metaspace);
+            cycle.setMetaspaceSummary(metaspaceSummary);
             cycle.setLoadAverages(load);
             cycle.setMMU(mmu);
+            cycle.setMarkSummary(markSummary);
             return cycle;
         }
 
+
         public void setPauseMarkStart(DateTimeStamp pauseMarkStart) {
-            if (this.pauseMarkStart != null) {
-                return;
-            }
             this.pauseMarkStart = pauseMarkStart;
         }
 
         public void setPauseMarkStartDuration(double pauseMarkStartDuration) {
-            this.pauseMarkStartDuration += pauseMarkStartDuration;
+            this.pauseMarkStartDuration = pauseMarkStartDuration;
         }
 
         public void setPauseMarkEndStart(DateTimeStamp pauseMarkEndStart) {
-            if (this.pauseMarkEndStart != null) {
-                return;
-            }
             this.pauseMarkEndStart = pauseMarkEndStart;
         }
 
         public void setPauseMarkEndDuration(double pauseMarkEndDuration) {
-            this.pauseMarkEndDuration += pauseMarkEndDuration;
+            this.pauseMarkEndDuration = pauseMarkEndDuration;
         }
 
         public void setPauseRelocateStart(DateTimeStamp pauseRelocateStart) {
-            if (this.pauseRelocateStart != null) {
-                return;
-            }
             this.pauseRelocateStart = pauseRelocateStart;
         }
 
         public void setPauseRelocateStartDuration(double pauseRelocateStartDuration) {
-            this.pauseRelocateStartDuration += pauseRelocateStartDuration;
+            this.pauseRelocateStartDuration = pauseRelocateStartDuration;
         }
 
         public void setConcurrentMarkStart(DateTimeStamp concurrentMarkStart) {
-            if (this.concurrentMarkStart != null) {
-                return;
-            }
             this.concurrentMarkStart = concurrentMarkStart;
         }
 
         public void setConcurrentMarkDuration(double concurrentMarkDuration) {
-            this.concurrentMarkDuration += concurrentMarkDuration;
+            this.concurrentMarkDuration = concurrentMarkDuration;
         }
 
         public void setConcurrentMarkFreeStart(DateTimeStamp concurrentMarkFreeStart) {
-            if (this.concurrentMarkFreeStart != null) {
-                return;
-            }
             this.concurrentMarkFreeStart = concurrentMarkFreeStart;
         }
         public void setConcurrentMarkFreeDuration(double concurrentMarkFreeDuration) {
-            this.concurrentMarkFreeDuration += concurrentMarkFreeDuration;
+            this.concurrentMarkFreeDuration = concurrentMarkFreeDuration;
         }
 
         public void setConcurrentProcessNonStringReferencesStart(DateTimeStamp concurrentProcessNonStringReferencesStart) {
-            if (this.concurrentProcessNonStringReferencesStart != null) {
-                return;
-            }
             this.concurrentProcessNonStringReferencesStart = concurrentProcessNonStringReferencesStart;
         }
 
         public void setConcurrentProcessNonStrongReferencesDuration(double concurrentProcessNonStrongReferencesDuration) {
-            this.concurrentProcessNonStrongReferencesDuration += concurrentProcessNonStrongReferencesDuration;
+            this.concurrentProcessNonStrongReferencesDuration = concurrentProcessNonStrongReferencesDuration;
         }
 
         public void setConcurrentResetRelocationSetStart(DateTimeStamp concurrentResetRelocationSetStart) {
-            if (this.concurrentResetRelocationSetStart != null) {
-                return;
-            }
             this.concurrentResetRelocationSetStart = concurrentResetRelocationSetStart;
         }
 
         public void setConcurrentResetRelocationSetDuration(double concurrentResetRelocationSetDuration) {
-            this.concurrentResetRelocationSetDuration += concurrentResetRelocationSetDuration;
+            this.concurrentResetRelocationSetDuration = concurrentResetRelocationSetDuration;
         }
 
         public void setConcurrentSelectRelocationSetStart(DateTimeStamp concurrentSelectRelocationSetStart) {
-            if (this.concurrentSelectRelocationSetStart != null) {
-                return;
-            }
             this.concurrentSelectRelocationSetStart = concurrentSelectRelocationSetStart;
         }
 
         public void setConcurrentSelectRelocationSetDuration(double concurrentSelectRelocationSetDuration) {
-            this.concurrentSelectRelocationSetDuration += concurrentSelectRelocationSetDuration;
+            this.concurrentSelectRelocationSetDuration = concurrentSelectRelocationSetDuration;
         }
 
         public void setConcurrentSelectRelocateStart(DateTimeStamp concurrentSelectRelocateStart) {
-            if (this.concurrentSelectRelocateStart != null) {
-                return;
-            }
             this.concurrentSelectRelocateStart = concurrentSelectRelocateStart;
         }
 
         public void setConcurrentSelectRelocateDuration(double concurrentSelectRelocateDuration) {
-            this.concurrentSelectRelocateDuration += concurrentSelectRelocateDuration;
-        }
-
-        public void setMemoryScope(ZGCMemoryScope scope) {
-            this.memoryScope = scope;
+            this.concurrentSelectRelocateDuration = concurrentSelectRelocateDuration;
         }
 
         //Memory
         public void setMarkStart(ZGCMemoryPoolSummary summary) {
-            if (memoryScope != ZGCMemoryScope.ALL) {
-                return;
-            }
             this.markStart = summary;
         }
 
         public void setMarkEnd(ZGCMemoryPoolSummary summary) {
-            if (memoryScope != ZGCMemoryScope.ALL) {
-                return;
-            }
             this.markEnd = summary;
         }
 
         public void setRelocateStart(ZGCMemoryPoolSummary summary) {
-            if (memoryScope != ZGCMemoryScope.ALL) {
-                return;
-            }
             this.relocatedStart = summary;
         }
 
         public void setRelocateEnd(ZGCMemoryPoolSummary summary) {
-            if (memoryScope != ZGCMemoryScope.ALL) {
-                return;
-            }
             this.relocateEnd = summary;
         }
 
-        public void setMarkedLive(OccupancySummary summary) {
-            this.markedLive = summary.sum(this.markedLive);
+        public void setMarkedLiveSummary(ZGCLiveSummary summary) {
+            this.liveSummary = summary;
         }
 
-        public void setAllocated(OccupancySummary summary) {
-            this.allocated = summary.sum(this.allocated);
+        public void setAllocatedSummary(ZGCAllocatedSummary summary) {
+            this.allocatedSummary = summary;
         }
 
-        public void setGarbage(OccupancySummary summary) {
-            this.garbage = summary.sum(this.garbage);
+        public void setGarbageSummary(ZGCGarbageSummary summary) {
+            this.garbageSummary = summary;
         }
 
-        public void setReclaimed(ReclaimSummary summary) {
-            this.reclaimed = summary.sum(this.reclaimed);
+        public void setReclaimSummary(ZGCReclaimSummary summary) {
+            reclaimSummary = summary;
         }
 
-        public void setMemorySummary(ReclaimSummary summary) {
+        public void setMemorySummary(ZGCMemorySummary summary) {
             this.memorySummary = summary;
         }
 
-        public void setMetaspace(ZGCMetaspaceSummary summary) {
-            this.metaspace = summary;
+        public void setMetaspaceSummary(ZGCMetaspaceSummary summary) {
+            this.metaspaceSummary = summary;
         }
 
         public void setLoad(double[] load) {
@@ -556,6 +894,117 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
 
         public void setMMU(double[] mmu) {
             this.mmu = mmu;
+        }
+
+        public void setConcurrentMarkContinueStart(DateTimeStamp startTime) {
+            this.concurrentMarkContinueStart = startTime;
+        }
+
+        public void setConcurrentMarkContinueDuration(double duration) {
+            this.concurrentMarkContinueDuration = duration;
+        }
+
+        public void setConcurrentRemapRootsStart(DateTimeStamp startTime) {
+            this.concurrentRemapRootsStart = startTime;
+        }
+
+        public void setConcurrentRemapRootsDuration(double duration) {
+            this.concurrentRemapRootsDuration = duration;
+        }
+
+        public void setMarkRootsStart(DateTimeStamp startTime) {
+
+            this.markRootsStart = startTime;
+        }
+
+        public void setMarkRootsDuration(double duration) {
+
+            this.markRootsDuration = duration;
+        }
+
+        public void setMarkFollowStart(DateTimeStamp markFollowStart) {
+
+            this.markFollowStart = markFollowStart;
+        }
+
+        public void setMarkFollowDuration(double markFollowDuration) {
+
+            this.markFollowDuration = markFollowDuration;
+        }
+
+        public void setRemapRootsColoredStart(DateTimeStamp remapRootColoredStart) {
+
+            this.remapRootColoredStart = remapRootColoredStart;
+        }
+
+        public void setRemapRootsColoredDuration(double remapRootsColoredDuration) {
+
+            this.remapRootsColoredDuration = remapRootsColoredDuration;
+        }
+
+        public void setRemapRootsUncoloredStart(DateTimeStamp remapRootsUncoloredStart) {
+
+            this.remapRootsUncoloredStart = remapRootsUncoloredStart;
+        }
+
+        public void setRemapRootsUncoloredDuration(double remapRootsUncoloredDuration) {
+
+            this.remapRootsUncoloredDuration = remapRootsUncoloredDuration;
+        }
+
+        public void setRemapRememberedStart(DateTimeStamp remapRememberedStart) {
+
+            this.remapRememberedStart = remapRememberedStart;
+        }
+
+        public void setRemapRememberedDuration(double remapRememberedDuration) {
+
+            this.remapRememberedDuration = remapRememberedDuration;
+        }
+
+        public void setMarkSummary(ZGCMarkSummary markSummary) {
+            this.markSummary = markSummary;
+        }
+
+        public void setPromotedSummary(ZGCPromotedSummary promotedSummary) {
+            this.promotedSummary = promotedSummary;
+        }
+
+        public void setCompactedSummary(ZGCCompactedSummary compactedSummary) {
+            this.compactedSummary = compactedSummary;
+        }
+
+        public void setGcDuration(double gcDuration) {
+            this.gcDuration = gcDuration;
+        }
+
+        public void setUsed(ZGCPhase phase, OccupancySummary summary) {
+            switch (phase) {
+                case FULL:
+                    // does not apply to non generational GC
+                    break;
+                case MAJOR_YOUNG:
+                case MAJOR_OLD:
+                case MINOR_YOUNG:
+                    this.usedOccupancySummary = summary;
+                    break;
+            }
+        }
+
+        public void setSoftRefSummary(ZGCReferenceSummary summary) {
+            this.softRefSummary = summary;
+        }
+
+        public void setWeakRefSummary(ZGCReferenceSummary weakRefSummary) {
+            this.weakRefSummary = weakRefSummary;
+        }
+
+        public void setFinalRefSummary(ZGCReferenceSummary finalRefSummary) {
+            this.finalRefSummary = finalRefSummary;
+        }
+
+        public void setPhantomRefSummary(ZGCReferenceSummary phantomRefSummary) {
+            this.phantomRefSummary = phantomRefSummary;
         }
     }
 

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
@@ -7,61 +7,73 @@ import com.microsoft.gctoolkit.parser.GenericTokens;
 
 public interface ZGCPatterns extends UnifiedPatterns {
 
-    String MEMORY_PERCENT = GenericTokens.INT + GenericTokens.UNITS + "\\s*\\(" + GenericTokens.INT + "%\\)";
+    // Optional Generation tag, Generation ZGC has tags where legacy ZGC does not
+    // Y -> Major Young gen
+    // O -> Major Old gen
+    // y -> Minor Young gen
+    String OPT_GEN = "(?:(y|O|Y):)?\\s*";
 
-    String LOAD_PERCENT = GenericTokens.REAL_VALUE + " \\(" + GenericTokens.INTEGER + "%\\)";
+    String MEMORY_PERCENT = GenericTokens.INT + GenericTokens.UNITS + "\\s*\\(" + GenericTokens.INT + "%\\)";
 
     GCParseRule ZGC_TAG = new GCParseRule("ZGC Tag", "Initializing The Z Garbage Collector$");
 
     //[3.558s][info ][gc,start       ] GC(3) Garbage Collection (Warmup)
-    GCParseRule CYCLE_START = new GCParseRule("CYCLE_START", "GC\\(" + GenericTokens.INT + "\\) (?:Garbage|Major|Minor) Collection " + GenericTokens.GC_CAUSE + "$");
+    GCParseRule CYCLE_START = new GCParseRule("CYCLE_START", "GC\\(" + GenericTokens.INT + "\\) (Garbage|Major|Minor) Collection " + GenericTokens.GC_CAUSE + "$");
 
     //[3.559s][info ][gc,phases      ] GC(3) Pause Mark Start 0.460ms
     //[3.574s][info ][gc,phases      ] GC(3) Pause Mark End 0.830ms
     //[3.583s][info ][gc,phases      ] GC(3) Pause Relocate Start 0.794ms
-    GCParseRule PAUSE_PHASE = new GCParseRule("Pause Phase", "Pause (Mark Start|Mark End|Relocate Start)(?: \\((Major|Minor)\\))? " + GenericTokens.PAUSE_TIME);
+    GCParseRule PAUSE_PHASE = new GCParseRule("Pause Phase", OPT_GEN + "Pause (Mark Start|Mark Start \\(Major\\)|Mark End|Relocate Start) " + GenericTokens.PAUSE_TIME);
 
     //[3.573s][info ][gc,phases      ] GC(3) Concurrent Mark 14.621ms
     //[3.578s][info ][gc,phases      ] GC(3) Concurrent Process Non-Strong References 3.654ms
     //[3.578s][info ][gc,phases      ] GC(3) Concurrent Reset Relocation Set 0.194ms
     //[3.582s][info ][gc,phases      ] GC(3) Concurrent Select Relocation Set 3.193ms
     //[3.596s][info ][gc,phases      ] GC(3) Concurrent Relocate 12.962ms
-    GCParseRule CONCURRENT_PHASE = new GCParseRule("Concurrent Phase","Concurrent (Mark|Mark Free|Process Non-Strong References|Process Non-Strong|Reset Relocation Set|Select Relocation Set|Relocate) " + GenericTokens.PAUSE_TIME);
+    GCParseRule CONCURRENT_PHASE = new GCParseRule("Concurrent Phase", OPT_GEN + "Concurrent (Mark|Mark Continue|Mark Free|Process Non-Strong|Process Non-Strong References|Reset Relocation Set|Select Relocation Set|Relocate|Remap Roots|Mark Roots|Mark Follow|Remap Roots Colored|Remap Roots Uncolored|Remap Remembered) " + GenericTokens.PAUSE_TIME);
 
     //[3.596s][info ][gc,load        ] GC(3) Load: 4.28/3.95/3.22
-    GCParseRule LOAD = new GCParseRule("Load","Load: " + GenericTokens.REAL_VALUE + "/" + GenericTokens.REAL_VALUE + "/" + GenericTokens.REAL_VALUE);
+    GCParseRule LOAD = new GCParseRule("Load", OPT_GEN + "Load: " + GenericTokens.REAL_VALUE + "/" + GenericTokens.REAL_VALUE + "/" + GenericTokens.REAL_VALUE);
 
-    // [4.220s][info][gc,load     ] GC(0) O: Load: 9.07 (19%) / 9.48 (20%) / 10.07 (21%)
-    GCParseRule GENERATION_LOAD = new GCParseRule("Load","Load: " + LOAD_PERCENT + " / " + LOAD_PERCENT + " / " + LOAD_PERCENT);
+    //[2025-02-11T13:21:06.542-0800][info][gc,load     ] GC(49) O: Load: 18.77 (52%) / 17.33 (48%) / 15.99 (44%)
+    GCParseRule LOAD_GEN = new GCParseRule("Load Gen", OPT_GEN + "Load: " + GenericTokens.REAL_VALUE +  " \\(\\d+%?\\) \\/ " + GenericTokens.REAL_VALUE + " \\(\\d+%?\\) \\/ " + GenericTokens.REAL_VALUE + " \\(\\d+%?\\)");
 
     //[3.596s][info ][gc,mmu         ] GC(3) MMU: 2ms/32.7%, 5ms/60.8%, 10ms/80.4%, 20ms/85.4%, 50ms/90.8%, 100ms/95.4%
-    GCParseRule MMU = new GCParseRule("MMU","MMU: 2ms/" + GenericTokens.PERCENTAGE + ", 5ms/" + GenericTokens.PERCENTAGE + ", 10ms/" + GenericTokens.PERCENTAGE + ", 20ms/" + GenericTokens.PERCENTAGE + ", 50ms/" + GenericTokens.PERCENTAGE + ", 100ms/" + GenericTokens.PERCENTAGE);
+    GCParseRule MMU = new GCParseRule("MMU", OPT_GEN + "MMU: 2ms/" + GenericTokens.PERCENTAGE + ", 5ms/" + GenericTokens.PERCENTAGE + ", 10ms/" + GenericTokens.PERCENTAGE + ", 20ms/" + GenericTokens.PERCENTAGE + ", 50ms/" + GenericTokens.PERCENTAGE + ", 100ms/" + GenericTokens.PERCENTAGE);
 
     //[3.596s][info ][gc,marking     ] GC(3) Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 1 completion(s), 0 continuation(s)",
-    GCParseRule MARK_SUMMARY = new GCParseRule("Mark Summary","Mark: (\\d+) stripe\\(s\\), ");
+    GCParseRule MARK_SUMMARY = new GCParseRule("Mark Summary",OPT_GEN + "Mark: " + INT + " stripe\\(s\\), " + INT + " proactive flush\\(es\\), " + INT + " terminate flush\\(es\\), " + INT + " completion\\(s\\), " + INT + " continuation\\(s\\)");
 
     //[3.596s][info ][gc,reloc       ] GC(3) Relocation: Successful, 6M relocated
-    GCParseRule RELOCATION_SUMMARY = new GCParseRule("Relocation Summary","Relocation: Successful, (\\d+)M relocated");
+    GCParseRule RELOCATION_SUMMARY = new GCParseRule("Relocation Summary",OPT_GEN + "Relocation: Successful, (\\d+)M relocated");
 
     //[3.596s][info ][gc,nmethod     ] GC(3) NMethods: 1163 registered, 0 unregistered
-    GCParseRule NMETHODS = new GCParseRule("NMethods"," NMethods: " + GenericTokens.INT + " registered, " + GenericTokens.INT + " unregistered");
+    GCParseRule NMETHODS = new GCParseRule("NMethods",OPT_GEN + " NMethods: " + GenericTokens.INT + " registered, " + GenericTokens.INT + " unregistered");
 
     //[3.596s][info ][info ][gc,metaspace   ] GC(3) Metaspace: 84M used, 85M committed, 1104M reserved
-    GCParseRule METASPACE = new GCParseRule( "Metaspace", "Metaspace: " + GenericTokens.INT + GenericTokens.UNITS + " used, " + GenericTokens.INT + GenericTokens.UNITS + " committed, " + GenericTokens.INT + GenericTokens.UNITS + " reserved");
+    GCParseRule METASPACE = new GCParseRule( "Metaspace", OPT_GEN + "Metaspace: " + GenericTokens.INT + GenericTokens.UNITS + " used, " + GenericTokens.INT + GenericTokens.UNITS + " committed, " + GenericTokens.INT + GenericTokens.UNITS + " reserved");
 
     //[3.596s][info ][gc,ref         ] GC(3) Soft: 391 encountered, 0 discovered, 0 enqueued
     //[3.596s][info ][gc,ref         ] GC(3) Weak: 587 encountered, 466 discovered, 0 enqueued
     //[3.596s][info ][gc,ref         ] GC(3) Final: 799 encountered, 0 discovered, 0 enqueued
     //[3.596s][info ][gc,ref         ] GC(3) Phantom: 33 encountered, 1 discovered, 0 enqueued
-    GCParseRule REFERENCE_PROCESSING = new GCParseRule("Reference Processing", "(Soft|Weak|Final|Phantom): " + GenericTokens.COUNTER + " encountered, " + GenericTokens.COUNTER + " discovered, " + GenericTokens.COUNTER + " enqueued");
+    GCParseRule REFERENCE_PROCESSING = new GCParseRule("Reference Processing", OPT_GEN + "(Soft|Weak|Final|Phantom): " + GenericTokens.COUNTER + " encountered, " + GenericTokens.COUNTER + " discovered, " + GenericTokens.COUNTER + " enqueued");
+
+    // Generation ZGC
+    //[2025-02-11T13:06:17.709-0800][info][gc,ref      ] GC(0) O:                       Encountered   Discovered     Enqueued
+    //[2025-02-11T13:06:17.709-0800][info][gc,ref      ] GC(0) O: Soft References:             3642            0            0
+    //[2025-02-11T13:06:17.709-0800][info][gc,ref      ] GC(0) O: Weak References:             1507            0            0
+    //[2025-02-11T13:06:17.709-0800][info][gc,ref      ] GC(0) O: Final References:               0            0            0
+    //[2025-02-11T13:06:17.709-0800][info][gc,ref      ] GC(0) O: Phantom References:           176            0            0
+    GCParseRule REFERENCE_PROCESSING_GEN = new GCParseRule("Reference Processing", OPT_GEN + "(Soft|Weak|Final|Phantom) References:\\s+" + GenericTokens.COUNTER + "\\s+" + GenericTokens.COUNTER + "\\s+" + GenericTokens.COUNTER);
 
     //[3.596s][info ][gc,heap        ] GC(3) Min Capacity: 8M(0%)
     //[3.596s][info ][gc,heap        ] GC(3) Max Capacity: 4096M(100%)
     //[3.596s][info ][gc,heap        ] GC(3) Soft Max Capacity: 4096M(100%)
-    GCParseRule CAPACITY = new GCParseRule("Capacity", "(Min Capacity|Max Capacity|Soft Max Capacity): " + MEMORY_PERCENT);
+    GCParseRule CAPACITY = new GCParseRule("Capacity", OPT_GEN + "(Min Capacity|Max Capacity|Soft Max Capacity): " + MEMORY_PERCENT);
 
     //[3.596s][info ][gc,heap        ] GC(3)                Mark Start          Mark End        Relocate Start      Relocate End           High               Low
-    GCParseRule MEMORY_TABLE_HEADER = new GCParseRule("Memory Table Header", "Mark Start\\s+Mark End\\s+Relocate Start");
+    GCParseRule MEMORY_TABLE_HEADER = new GCParseRule("Memory Table Header", OPT_GEN + "Mark Start\\s+Mark End\\s+Relocate Start");
 
     //[3.596s][info ][gc,heap        ] GC(3)  Capacity:    36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)
     //[3.596s][info ][gc,heap        ] GC(3)      Free:    30614M (83%)       30460M (83%)       30988M (84%)       35938M (97%)       35938M (97%)       30458M (83%)
@@ -69,18 +81,39 @@ public interface ZGCPatterns extends UnifiedPatterns {
     //************
     //This rule is scary in that it captures CAPACITY IF the spaces are removed from before 'Capacity' in the capture group below.
     //****** WARNING DO NOT REMOVE SPACES FROM THE RULE ******* THINGS WILL BREAK!!!! *************
-    GCParseRule MEMORY_TABLE_ENTRY_SIZE = new GCParseRule("Memory table entry size", "\\s*(Capacity||Free|Used):\\s+" + MEMORY_PERCENT + "\\s*" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT);
+    GCParseRule MEMORY_TABLE_ENTRY_SIZE = new GCParseRule("Memory table entry size", OPT_GEN + "\\s*(Capacity||Free|Used):\\s+" + MEMORY_PERCENT + "\\s*" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT);
+
+    // Gen ZGC
+    // [info][gc,heap     ] GC(2) O: Old Generation Statistics:
+    GCParseRule MARK_OLD_GEN_HEAP_STATS = new GCParseRule("Mark Old Gen Stats", OPT_GEN + "Old Generation Statistics");
+
+    // Gen ZGC
+    // [info][gc,heap     ] GC(4) Y: Young Generation Statistics:
+    GCParseRule MARK_YOUNG_GEN_HEAP_STATS = new GCParseRule("Mark Young Gen Stats", OPT_GEN + "Young Generation Statistics");
 
     //[3.596s][info ][gc,heap        ] GC(3)      Live:         -                 8M (0%)            8M (0%)            8M (0%)             -                  -
     //[3.596s][info ][gc,heap        ] GC(3) Allocated:         -               172M (4%)          172M (4%)          376M (9%)             -                  -
     //[3.596s][info ][gc,heap        ] GC(3)   Garbage:         -               885M (22%)         117M (3%)            5M (0%)             -                  -
-    GCParseRule MEMORY_TABLE_ENTRY_OCCUPANCY = new GCParseRule("Memory table entry occupancies", "(Live|Allocated|Garbage):\\s+-\\s+"  + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT);
+    GCParseRule MEMORY_TABLE_ENTRY_OCCUPANCY = new GCParseRule("Memory table entry occupancies", OPT_GEN + "(Live|Allocated|Garbage):\\s+-\\s+"  + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT);
 
-    //[3.596s][info ][gc,heap        ] GC(3) Reclaimed:         -                  -               768M (19%)         880M (21%)            -                  -
-    GCParseRule MEMORY_TABLE_ENTRY_RECLAIMED = new GCParseRule("Memory table entry reclaimed", "Reclaimed:\\s*-\\s*-\\s*" + MEMORY_PERCENT + "\\s*" + MEMORY_PERCENT);
+    //[info][gc,heap     ] GC(7) y: Reclaimed:         -                  -              2554M (7%)        14009M (38%)
+    //[info][gc,heap     ] GC(7) y:  Promoted:         -                  -                 0M (0%)            0M (0%)
+    GCParseRule MEMORY_TABLE_ENTRY_RECLAIMED_PROMOTED = new GCParseRule("Memory table entry reclaimed", OPT_GEN + "(Reclaimed|Promoted):\\s*-\\s*-\\s*" + MEMORY_PERCENT + "\\s*" + MEMORY_PERCENT);
 
-    //[3.596s][info ][gc             ] GC(3) Garbage Collection (Warmup) 894M(22%)->186M(5%)
-    GCParseRule MEMORY_SUMMARY = new GCParseRule("Memory Summary","(?:Garbage|Major|Minor) Collection " + GenericTokens.GC_CAUSE + MEMORY_PERCENT + "->" + MEMORY_PERCENT);
+    // Generational ZGC
+    // [2025-02-11T13:21:45.856-0800][info][gc,heap     ] GC(51) y: Compacted:         -                  -                  -                88M (0%)
+    GCParseRule MEMORY_TABLE_ENTRY_COMPACTED = new GCParseRule("Memory table entry compacted", OPT_GEN + "Compacted:\\s*-\\s*-\\s*-\\s*" + MEMORY_PERCENT);
+
+    // [info][gc,phases   ] GC(58) Y: Young Generation 16052M(44%)->3022M(8%) 1.017s
+    // [info][gc,phases   ] GC(58) O: Old Generation 3022M(8%)->5486M(15%) 1.757s
+    GCParseRule END_OF_PHASE_SUMMARY_GEN = new GCParseRule("End of Phase Summary", OPT_GEN + "(Old|Young) Generation " + MEMORY_PERCENT + "->" + MEMORY_PERCENT + "\\s*" + DURATION_S);
+
+
+    //[3.596s][info ][gc         ] GC(3) Garbage Collection (Warmup) 894M(22%)->186M(5%)
+    // or
+    // Gen GC
+    //[3.596s][info][gc          ] GC(7) Minor Collection (Allocation Rate) 14720M(40%)->2054M(6%) 0.689s
+    GCParseRule MEMORY_SUMMARY = new GCParseRule("Memory Summary", "(Garbage|Minor|Major) Collection " + GenericTokens.GC_CAUSE + MEMORY_PERCENT + "->" + MEMORY_PERCENT + "(?:\\s*" + DURATION_S + ")?" );
 
     /*
     todo: capture and report on these log entries

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/GenerationalZGCParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/GenerationalZGCParserTest.java
@@ -1,0 +1,431 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.gctoolkit.parser;
+
+import com.microsoft.gctoolkit.event.jvm.JVMEvent;
+import com.microsoft.gctoolkit.event.zgc.MajorZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.MinorZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.OccupancySummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCAllocatedSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCCompactedSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.ZGCGarbageSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCLiveSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCMemoryPoolSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCMemorySummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCMetaspaceSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCPromotedSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCReclaimSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCReferenceSummary;
+import com.microsoft.gctoolkit.jvm.Diarizer;
+import com.microsoft.gctoolkit.parser.jvm.UnifiedDiarizer;
+import com.microsoft.gctoolkit.time.DateTimeStamp;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class GenerationalZGCParserTest extends ParserTest {
+
+    @Override
+    protected Diarizer diarizer() {
+        return new UnifiedDiarizer();
+    }
+
+    protected GCLogParser parser() {
+        return new ZGCParser();
+    }
+
+    @Test
+    public void testZgcMajorCycle() {
+        String[] eventLogEntries = {
+                "[2025-02-11T13:06:19.476-0800][info][gc          ] GC(1) Major Collection (Metadata GC Threshold)",
+                "[2025-02-11T13:06:19.476-0800][info][gc,phases   ] GC(1) Y: Young Generation",
+                "[2025-02-11T13:06:19.476-0800][info][gc,phases   ] GC(1) Y: Pause Mark Start (Major) 0.023ms",
+                "[2025-02-11T13:06:19.534-0800][info][gc,phases   ] GC(1) Y: Concurrent Mark 57.581ms",
+                "[2025-02-11T13:06:19.534-0800][info][gc,phases   ] GC(1) Y: Pause Mark End 0.016ms",
+                "[2025-02-11T13:06:19.534-0800][info][gc,phases   ] GC(1) Y: Concurrent Mark Free 0.001ms",
+                "[2025-02-11T13:06:19.534-0800][info][gc,phases   ] GC(1) Y: Concurrent Reset Relocation Set 0.005ms",
+                "[2025-02-11T13:06:19.536-0800][info][gc,reloc    ] GC(1) Y: Using tenuring threshold: 2 (Computed)",
+                "[2025-02-11T13:06:19.538-0800][info][gc,phases   ] GC(1) Y: Concurrent Select Relocation Set 3.879ms",
+                "[2025-02-11T13:06:19.538-0800][info][gc,phases   ] GC(1) Y: Pause Relocate Start 0.008ms",
+                "[2025-02-11T13:06:19.551-0800][info][gc,phases   ] GC(1) Y: Concurrent Relocate 13.129ms",
+                "[2025-02-11T13:06:19.551-0800][info][gc,load     ] GC(1) Y: Load: 7.61 (21%) / 12.83 (36%) / 13.76 (38%)",
+                "[2025-02-11T13:06:19.551-0800][info][gc,mmu      ] GC(1) Y: MMU: 2ms/98.9%, 5ms/99.5%, 10ms/99.8%, 20ms/99.8%, 50ms/99.9%, 100ms/99.9%",
+                "[2025-02-11T13:06:19.551-0800][info][gc,marking  ] GC(1) Y: Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s) ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,marking  ] GC(1) Y: Mark Stack Usage: 32M",
+                "[2025-02-11T13:06:19.551-0800][info][gc,metaspace] GC(1) Y: Metaspace: 36M used, 37M committed, 1088M reserved",
+                "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y:                        Candidates     Selected     In-Place         Size        Empty    Relocated ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y: Small Pages:                  112           85            0         224M          36M           6M ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y: Medium Pages:                   2            0            0          64M          32M           0M ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y: Large Pages:                    1            0            0           8M           0M           0M ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y: Forwarding Usage: 3M",
+                "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y: Age Table:",
+                "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y:                    Live             Garbage             Small              Medium             Large        ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y: Eden               8M (0%)          223M (1%)         100 / 78             1 / 0              0 / 0        ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y: Survivor 1        16M (0%)           47M (0%)          12 / 7              1 / 0              1 / 0        ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y: Min Capacity: 36864M(100%)",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y: Max Capacity: 36864M(100%)",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y: Soft Max Capacity: 36864M(100%)",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y: Heap Statistics:",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y:                Mark Start          Mark End        Relocate Start      Relocate End           High               Low         ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y:  Capacity:    36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)   ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y:      Free:    36568M (99%)       36556M (99%)       36624M (99%)       36788M (100%)      36788M (100%)      36556M (99%)    ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y:      Used:      296M (1%)          308M (1%)          240M (1%)           76M (0%)          308M (1%)           76M (0%)     ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y: Young Generation Statistics:",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y:                Mark Start          Mark End        Relocate Start      Relocate End    ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y:      Used:      296M (1%)          308M (1%)          240M (1%)           76M (0%)     ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y:      Live:         -                24M (0%)           24M (0%)           24M (0%)     ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y:   Garbage:         -               271M (1%)          203M (1%)           31M (0%)     ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y: Allocated:         -                12M (0%)           12M (0%)           19M (0%)     ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y: Reclaimed:         -                  -                68M (0%)          239M (1%)     ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y:  Promoted:         -                  -                 0M (0%)            0M (0%)     ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,heap     ] GC(1) Y: Compacted:         -                  -                  -                10M (0%)     ",
+                "[2025-02-11T13:06:19.551-0800][info][gc,phases   ] GC(1) Y: Young Generation 296M(1%)->76M(0%) 0.075s",
+                "[2025-02-11T13:06:19.551-0800][info][gc,phases   ] GC(1) O: Old Generation",
+                "[2025-02-11T13:06:19.553-0800][info][gc,phases   ] GC(1) O: Concurrent Mark 1.286ms",
+                "[2025-02-11T13:06:19.553-0800][info][gc,phases   ] GC(1) O: Pause Mark End 0.017ms",
+                "[2025-02-11T13:06:19.553-0800][info][gc,phases   ] GC(1) O: Concurrent Mark Free 0.000ms",
+                "[2025-02-11T13:06:19.562-0800][info][gc,phases   ] GC(1) O: Concurrent Process Non-Strong 9.598ms",
+                "[2025-02-11T13:06:19.562-0800][info][gc,phases   ] GC(1) O: Concurrent Reset Relocation Set 0.001ms",
+                "[2025-02-11T13:06:19.564-0800][info][gc,phases   ] GC(1) O: Concurrent Select Relocation Set 2.012ms",
+                "[2025-02-11T13:06:19.580-0800][info][gc,phases   ] GC(1) O: Concurrent Remap Roots 15.512ms",
+                "[2025-02-11T13:06:19.580-0800][info][gc,phases   ] GC(1) O: Pause Relocate Start 0.013ms",
+                "[2025-02-11T13:06:19.580-0800][info][gc,phases   ] GC(1) O: Concurrent Relocate 0.050ms",
+                "[2025-02-11T13:06:19.580-0800][info][gc,load     ] GC(1) O: Load: 7.61 (21%) / 12.83 (36%) / 13.76 (38%)",
+                "[2025-02-11T13:06:19.580-0800][info][gc,mmu      ] GC(1) O: MMU: 2ms/98.9%, 5ms/99.5%, 10ms/99.8%, 20ms/99.8%, 50ms/99.9%, 100ms/99.9%",
+                "[2025-02-11T13:06:19.580-0800][info][gc,marking  ] GC(1) O: Mark: 1 stripe(s), 1 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s) ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,marking  ] GC(1) O: Mark Stack Usage: 0M",
+                "[2025-02-11T13:06:19.580-0800][info][gc,metaspace] GC(1) O: Metaspace: 36M used, 37M committed, 1088M reserved",
+                "[2025-02-11T13:06:19.580-0800][info][gc,ref      ] GC(1) O:                       Encountered   Discovered     Enqueued ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,ref      ] GC(1) O: Soft References:             4193            0            0 ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,ref      ] GC(1) O: Weak References:             2798            0            0 ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,ref      ] GC(1) O: Final References:             719            0            0 ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,ref      ] GC(1) O: Phantom References:           497            0            0 ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O: Min Capacity: 36864M(100%)",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O: Max Capacity: 36864M(100%)",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O: Soft Max Capacity: 36864M(100%)",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O: Heap Statistics:",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O:                Mark Start          Mark End        Relocate Start      Relocate End           High               Low         ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O:  Capacity:    36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)   ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O:      Free:    36568M (99%)       36788M (100%)      36784M (100%)      36784M (100%)      36788M (100%)      36556M (99%)    ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O:      Used:      296M (1%)           76M (0%)           80M (0%)           80M (0%)          308M (1%)           76M (0%)     ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O: Old Generation Statistics:",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O:                Mark Start          Mark End        Relocate Start      Relocate End    ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O:      Used:        0M (0%)            0M (0%)            0M (0%)            0M (0%)     ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O:      Live:         -                 0M (0%)            0M (0%)            0M (0%)     ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O:   Garbage:         -                 0M (0%)            0M (0%)            0M (0%)     ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O: Allocated:         -                 0M (0%)            0M (0%)            0M (0%)     ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O: Reclaimed:         -                  -                 0M (0%)            0M (0%)     ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,heap     ] GC(1) O: Compacted:         -                  -                  -                 0M (0%)     ",
+                "[2025-02-11T13:06:19.580-0800][info][gc,phases   ] GC(1) O: Old Generation 76M(0%)->80M(0%) 0.029s",
+                "[2025-02-11T13:06:19.580-0800][info][gc          ] GC(1) Major Collection (Metadata GC Threshold) 296M(1%)->80M(0%) 0.105s",
+
+        };
+
+        List<JVMEvent> singleCycle = feedParser(eventLogEntries);
+        try {
+            assertEquals(1, singleCycle.size());
+            MajorZGCCycle zgc = (MajorZGCCycle) singleCycle.get(0);
+
+            assertEquals(zgc.getGcId(), 1L);
+
+            assertEquals(toInt(0.1039d,1000), toInt(zgc.getDuration(),1000));
+            assertEquals(toInt(1.739307979476E9, 1000), toInt(zgc.getDateTimeStamp().getTimeStamp(), 1000));
+            assertEquals("Metadata GC Threshold", zgc.getGCCause().getLabel());
+
+            /*
+             * Young Phase Checks
+             */
+            ZGCCycle young = zgc.getYoungCycle();
+            // Durations
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.476-0800", 0.023, young.getPauseMarkStartTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.534-0800", 57.581, young.getConcurrentMarkTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.534-0800", 0.001, young.getConcurrentMarkFreeTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.534-0800", 0.016, young.getPauseMarkEndTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.534-0800", 0.005, young.getConcurrentResetRelocationSetTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.538-0800", 3.879, young.getConcurrentSelectRelocationSetTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.538-0800", 0.008, young.getPauseRelocateStartTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.551-0800", 13.129, young.getConcurrentRelocateTimeStamp()));
+
+            assertEquals(toInt(0.023d, 1000), toInt(young.getPauseMarkStartDuration(), 1000));
+            assertEquals(toInt(57.581d, 1000), toInt(young.getConcurrentMarkDuration(), 1000));
+            assertEquals(toInt(0.001d, 1000), toInt(young.getConcurrentMarkFreeDuration(), 1000));
+            assertEquals(toInt(0.016d, 1000), toInt(young.getPauseMarkEndDuration(), 1000));
+            assertEquals(toInt(0.005d, 1000), toInt(young.getConcurrentResetRelocationSetDuration(), 1000));
+            assertEquals(toInt(3.879d, 1000), toInt(young.getConcurrentSelectRelocationSetDuration(), 1000));
+            assertEquals(toInt(0.008d, 1000), toInt(young.getPauseRelocateStartDuration(), 1000));
+            assertEquals(toInt(13.129d, 1000), toInt(young.getConcurrentRelocateDuration(), 1000));
+
+            //Memory
+            assertTrue(checkZGCMemoryPoolSummary(young.getMarkStart(), 36864, 36568, 296));
+            assertTrue(checkZGCMemoryPoolSummary(young.getMarkEnd(), 36864, 36556, 308));
+            assertTrue(checkZGCMemoryPoolSummary(young.getRelocateStart(),36864, 36624, 240));
+            assertTrue(checkZGCMemoryPoolSummary(young.getRelocateEnd(), 36864, 36788, 76));
+
+            assertTrue(checkZGCMetaSpaceSummary(young.getMetaspaceSummary(),36, 37, 1088));
+
+            assertTrue(checkUsedSummary(young.getUsedOccupancySummary(), 296, 308, 240, 76));
+            assertTrue(checkLiveSummary(young.getLiveSummary(), 24, 24, 24));
+            assertTrue(checkGarbageSummary(young.getGarbageSummary(), 271, 203, 31));
+            assertTrue(checkAllocatedSummary(young.getAllocatedSummary(), 12, 12, 19));
+
+            assertTrue(checkReclaimSummary(young.getReclaimSummary(), 68, 239));
+            assertTrue(checkPromotedSummary(young.getPromotedSummary(), 0, 0));
+            assertTrue(checkCompactedSummary(young.getCompactedSummary(), 10));
+
+            assertEquals(7.61, young.getLoadAverageAt(1));
+            assertEquals(12.83, young.getLoadAverageAt(5));
+            assertEquals(13.76, young.getLoadAverageAt(15));
+
+            assertEquals(98.9, young.getMMU(2));
+            assertEquals(99.5, young.getMMU(5));
+            assertEquals(99.8, young.getMMU(10));
+            assertEquals(99.8, young.getMMU(20));
+            assertEquals(99.9, young.getMMU(50));
+            assertEquals(99.9, young.getMMU(100));
+
+            assertTrue(checkMemorySummary(young.getMemorySummary(), 296, 76));
+
+            /*
+             * Old Phase Checks
+             */
+            ZGCCycle old = zgc.getOldCycle();
+            // Durations
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.553-0800", 1.286, old.getConcurrentMarkTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.553-0800", 0.017, old.getPauseMarkEndTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.553-0800", 0.000, old.getConcurrentMarkFreeTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.562-0800", 9.598, old.getConcurrentProcessNonStrongReferencesTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.562-0800", 0.001, old.getConcurrentResetRelocationSetTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.564-0800", 2.012, old.getConcurrentSelectRelocationSetTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.580-0800", 15.512, old.getConcurrentRemapRootsStart()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.580-0800", 0.013, old.getPauseRelocateStartTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:06:19.580-0800", 0.05, old.getConcurrentRelocateTimeStamp()));
+
+            assertEquals(toInt(1.286d, 1000), toInt(old.getConcurrentMarkDuration(), 1000));
+            assertEquals(toInt(0.017d, 1000), toInt(old.getPauseMarkEndDuration(), 1000));
+            assertEquals(toInt(0.000d, 1000), toInt(old.getConcurrentMarkFreeDuration(), 1000));
+            assertEquals(toInt(9.598d, 1000), toInt(old.getConcurrentProcessNonStrongReferencesDuration(), 1000));
+            assertEquals(toInt(0.001d, 1000), toInt(old.getConcurrentResetRelocationSetDuration(), 1000));
+            assertEquals(toInt(2.012d, 1000), toInt(old.getConcurrentSelectRelocationSetDuration(), 1000));
+            assertEquals(toInt(15.512d, 1000), toInt(old.getConcurrentRemapRootsDuration(), 1000));
+            assertEquals(toInt(0.013d, 1000), toInt(old.getPauseRelocateStartDuration(), 1000));
+            assertEquals(toInt(0.05d, 1000), toInt(old.getConcurrentRelocateDuration(), 1000));
+
+            assertTrue(checkReferenceSummary(old.getSoftRefSummary(), 4193, 0, 0));
+            assertTrue(checkReferenceSummary(old.getWeakRefSummary(), 2798, 0, 0));
+            assertTrue(checkReferenceSummary(old.getFinalRefSummary(), 719, 0, 0));
+            assertTrue(checkReferenceSummary(old.getPhantomRefSummary(), 497, 0, 0));
+
+            //Memory
+            assertTrue(checkZGCMemoryPoolSummary(old.getMarkStart(), 36864, 36568, 296));
+            assertTrue(checkZGCMemoryPoolSummary(old.getMarkEnd(), 36864, 36788, 76 ));
+            assertTrue(checkZGCMemoryPoolSummary(old.getRelocateStart(),36864, 36784, 80));
+            assertTrue(checkZGCMemoryPoolSummary(old.getRelocateEnd(), 36864, 36784, 80));
+
+            assertTrue(checkZGCMetaSpaceSummary(old.getMetaspaceSummary(),36, 37, 1088));
+
+            assertTrue(checkUsedSummary(old.getUsedOccupancySummary(), 0, 0, 0, 0));
+            assertTrue(checkLiveSummary(old.getLiveSummary(), 0, 0, 0));
+            assertTrue(checkGarbageSummary(old.getGarbageSummary(), 0, 0, 0));
+            assertTrue(checkAllocatedSummary(old.getAllocatedSummary(), 0, 0, 0));
+
+            assertTrue(checkReclaimSummary(old.getReclaimSummary(), 0, 0));
+            assertNull(old.getPromotedSummary());
+            assertTrue(checkCompactedSummary(old.getCompactedSummary(), 0));
+
+            assertEquals(7.61, old.getLoadAverageAt(1));
+            assertEquals(12.83, old.getLoadAverageAt(5));
+            assertEquals(13.76, old.getLoadAverageAt(15));
+
+            assertEquals(98.9, old.getMMU(2));
+            assertEquals(99.5, old.getMMU(5));
+            assertEquals(99.8, old.getMMU(10));
+            assertEquals(99.8, old.getMMU(20));
+            assertEquals(99.9, old.getMMU(50));
+            assertEquals(99.9, old.getMMU(100));
+
+            assertTrue(checkMemorySummary(old.getMemorySummary(), 76, 80));
+
+        } catch (Throwable t) {
+            fail(t);
+        }
+    }
+
+    @Test
+    public void testZgcMinorCycle() {
+        String[] eventLogEntries = {
+                "[2025-02-11T13:07:12.566-0800][info][gc          ] GC(7) Minor Collection (Allocation Rate)",
+                "[2025-02-11T13:07:12.566-0800][info][gc,phases   ] GC(7) y: Young Generation",
+                "[2025-02-11T13:07:12.566-0800][info][gc,phases   ] GC(7) y: Pause Mark Start 0.025ms",
+                "[2025-02-11T13:07:13.042-0800][info][gc,phases   ] GC(7) y: Concurrent Mark 475.464ms",
+                "[2025-02-11T13:07:13.042-0800][info][gc,phases   ] GC(7) y: Pause Mark End 0.022ms",
+                "[2025-02-11T13:07:13.042-0800][info][gc,phases   ] GC(7) y: Concurrent Mark Free 0.001ms",
+                "[2025-02-11T13:07:13.043-0800][info][gc,phases   ] GC(7) y: Concurrent Reset Relocation Set 0.652ms",
+                "[2025-02-11T13:07:13.049-0800][info][gc,reloc    ] GC(7) y: Using tenuring threshold: 3 (Computed)",
+                "[2025-02-11T13:07:13.056-0800][info][gc,phases   ] GC(7) y: Concurrent Select Relocation Set 13.394ms",
+                "[2025-02-11T13:07:13.057-0800][info][gc,phases   ] GC(7) y: Pause Relocate Start 0.017ms",
+                "[2025-02-11T13:07:13.255-0800][info][gc,phases   ] GC(7) y: Concurrent Relocate 198.752ms",
+                "[2025-02-11T13:07:13.255-0800][info][gc,load     ] GC(7) y: Load: 17.42 (48%) / 14.37 (40%) / 14.21 (39%)",
+                "[2025-02-11T13:07:13.255-0800][info][gc,mmu      ] GC(7) y: MMU: 2ms/97.7%, 5ms/99.1%, 10ms/99.5%, 20ms/99.8%, 50ms/99.9%, 100ms/99.9%",
+                "[2025-02-11T13:07:13.255-0800][info][gc,marking  ] GC(7) y: Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s) ",
+                "[2025-02-11T13:07:13.255-0800][info][gc,marking  ] GC(7) y: Mark Stack Usage: 32M",
+                "[2025-02-11T13:07:13.255-0800][info][gc,metaspace] GC(7) y: Metaspace: 100M used, 101M committed, 1152M reserved",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y:                        Candidates     Selected     In-Place         Size        Empty    Relocated ",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y: Small Pages:                 7066         5720            0       14132M        2554M          74M ",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y: Medium Pages:                   0            0            0           0M           0M           0M ",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y: Large Pages:                    0            0            0           0M           0M           0M ",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y: Forwarding Usage: 36M",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y: Age Table:",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y:                    Live             Garbage             Small              Medium             Large        ",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y: Eden              79M (0%)        13800M (37%)       6940 / 5622           0 / 0              0 / 0        ",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y: Survivor 1        25M (0%)          132M (0%)          79 / 61             0 / 0              0 / 0        ",
+                "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y: Survivor 2        15M (0%)           78M (0%)          47 / 37             0 / 0              0 / 0        ",
+                "[2025-02-11T13:07:13.255-0800][info][gc,heap     ] GC(7) y: Min Capacity: 36864M(100%)",
+                "[2025-02-11T13:07:13.255-0800][info][gc,heap     ] GC(7) y: Max Capacity: 36864M(100%)",
+                "[2025-02-11T13:07:13.255-0800][info][gc,heap     ] GC(7) y: Soft Max Capacity: 36864M(100%)",
+                "[2025-02-11T13:07:13.255-0800][info][gc,heap     ] GC(7) y: Heap Statistics:",
+                "[2025-02-11T13:07:13.255-0800][info][gc,heap     ] GC(7) y:                Mark Start          Mark End        Relocate Start      Relocate End           High               Low         ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y:  Capacity:    36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)      36864M (100%)   ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y:      Free:    22144M (60%)       21376M (58%)       23912M (65%)       34810M (94%)       34908M (95%)       21370M (58%)    ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y:      Used:    14720M (40%)       15488M (42%)       12952M (35%)        2054M (6%)        15494M (42%)        1956M (5%)     ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y: Young Generation Statistics:",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y:                Mark Start          Mark End        Relocate Start      Relocate End    ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y:      Used:    14132M (38%)       14900M (40%)       12364M (34%)        1466M (4%)     ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y:      Live:         -               120M (0%)          120M (0%)          120M (0%)     ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y:   Garbage:         -             14011M (38%)       11457M (31%)           2M (0%)     ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y: Allocated:         -               768M (2%)          786M (2%)         1343M (4%)     ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y: Reclaimed:         -                  -              2554M (7%)        14009M (38%)    ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y:  Promoted:         -                  -                 0M (0%)            0M (0%)     ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,heap     ] GC(7) y: Compacted:         -                  -                  -               104M (0%)     ",
+                "[2025-02-11T13:07:13.256-0800][info][gc,phases   ] GC(7) y: Young Generation 14720M(40%)->2054M(6%) 0.689s",
+                "[2025-02-11T13:07:13.256-0800][info][gc          ] GC(7) Minor Collection (Allocation Rate) 14720M(40%)->2054M(6%) 0.689s"
+
+        };
+
+        List<JVMEvent> singleCycle = feedParser(eventLogEntries);
+        try {
+            assertEquals(1, singleCycle.size());
+            MinorZGCCycle zgc = (MinorZGCCycle) singleCycle.get(0);
+
+            assertEquals(zgc.getGcId(), 7L);
+
+            assertEquals(toInt(0.690d,1000), toInt(zgc.getDuration(),1000));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:07:12.566-0800", 0, zgc.getDateTimeStamp()));
+            assertEquals("Allocation Rate", zgc.getGCCause().getLabel());
+
+            /*
+             * Young Phase Checks
+             */
+            ZGCCycle young = zgc.getYoungCycle();
+            // Durations
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:07:12.566-0800", 0.025, young.getPauseMarkStartTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:07:13.042-0800", 475.464, young.getConcurrentMarkTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:07:13.042-0800", 0.022, young.getPauseMarkEndTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:07:13.042-0800", 0.001, young.getConcurrentMarkFreeTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:07:13.043-0800", 0.652, young.getConcurrentResetRelocationSetTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:07:13.056-0800", 13.394, young.getConcurrentSelectRelocationSetTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:07:13.057-0800", 0.017, young.getPauseRelocateStartTimeStamp()));
+            assertTrue(checkDateTimeStampMatch("2025-02-11T13:07:13.255-0800", 198.752, young.getConcurrentRelocateTimeStamp()));
+
+            assertEquals(toInt(0.025d, 1000), toInt(young.getPauseMarkStartDuration(), 1000));
+            assertEquals(toInt(475.464d, 1000), toInt(young.getConcurrentMarkDuration(), 1000));
+            assertEquals(toInt(0.022d, 1000), toInt(young.getPauseMarkEndDuration(), 1000));
+            assertEquals(toInt(0.001d, 1000), toInt(young.getConcurrentMarkFreeDuration(), 1000));
+            assertEquals(toInt(0.652d, 1000), toInt(young.getConcurrentResetRelocationSetDuration(), 1000));
+            assertEquals(toInt(13.394d, 1000), toInt(young.getConcurrentSelectRelocationSetDuration(), 1000));
+            assertEquals(toInt(0.017d, 1000), toInt(young.getPauseRelocateStartDuration(), 1000));
+            assertEquals(toInt(198.752d, 1000), toInt(young.getConcurrentRelocateDuration(), 1000));
+
+            //Memory
+            assertTrue(checkZGCMemoryPoolSummary(young.getMarkStart(), 36864, 22144, 14720));
+            assertTrue(checkZGCMemoryPoolSummary(young.getMarkEnd(), 36864, 21376, 15488));
+            assertTrue(checkZGCMemoryPoolSummary(young.getRelocateStart(),36864, 23912, 12952));
+            assertTrue(checkZGCMemoryPoolSummary(young.getRelocateEnd(), 36864, 34810, 2054));
+
+            assertTrue(checkZGCMetaSpaceSummary(young.getMetaspaceSummary(),100, 101, 1152));
+
+            assertTrue(checkUsedSummary(young.getUsedOccupancySummary(), 14132, 14900, 12364, 1466));
+            assertTrue(checkLiveSummary(young.getLiveSummary(), 120, 120, 120));
+            assertTrue(checkGarbageSummary(young.getGarbageSummary(), 14011, 11457, 2));
+            assertTrue(checkAllocatedSummary(young.getAllocatedSummary(), 768, 786, 1343));
+
+            assertTrue(checkReclaimSummary(young.getReclaimSummary(), 2554, 14009));
+            assertTrue(checkPromotedSummary(young.getPromotedSummary(), 0, 0));
+            assertTrue(checkCompactedSummary(young.getCompactedSummary(), 104));
+
+            assertEquals(17.42, young.getLoadAverageAt(1));
+            assertEquals(14.37, young.getLoadAverageAt(5));
+            assertEquals(14.21, young.getLoadAverageAt(15));
+
+            assertEquals(97.7, young.getMMU(2));
+            assertEquals(99.1, young.getMMU(5));
+            assertEquals(99.5, young.getMMU(10));
+            assertEquals(99.8, young.getMMU(20));
+            assertEquals(99.9, young.getMMU(50));
+            assertEquals(99.9, young.getMMU(100));
+
+            assertTrue(checkMemorySummary(young.getMemorySummary(), 14720, 2054));
+        } catch (Throwable t) {
+            fail(t);
+        }
+    }
+
+    private boolean checkReferenceSummary(ZGCReferenceSummary refSummary, long encounderted, long discovered, long enqueued) {
+        return refSummary.getEncountered() == encounderted && refSummary.getDiscovered() == discovered && refSummary.getEnqueued() == enqueued;
+    }
+
+    private boolean checkUsedSummary(OccupancySummary summary, long markStart, long markEnd, long relocateStart, long relocateEnd) {
+        return summary.getMarkStart() == (markStart * 1024) && summary.getMarkEnd() == (markEnd * 1024) && summary.getReclaimStart() == (relocateStart * 1024) && summary.getReclaimEnd() == (relocateEnd * 1024);
+
+    }
+
+    private boolean checkDateTimeStampMatch(String expected, double offsetMs, DateTimeStamp dateTimeStamp) {
+       return new DateTimeStamp(expected).minus(offsetMs/1000).compareTo(dateTimeStamp) == 0;
+    }
+
+    private boolean checkZGCMetaSpaceSummary(ZGCMetaspaceSummary summary, long usedMb, long committedMb, long reservedMb) {
+        return summary.getUsed() ==(usedMb * 1024) && summary.getCommitted() == (committedMb * 1024) && summary.getReserved() == (reservedMb * 1024);
+    }
+
+    private boolean checkZGCMemoryPoolSummary(ZGCMemoryPoolSummary summary, long capacityMb, long freeMb , long usedMb) {
+        return summary.getCapacity() == (capacityMb * 1024) && summary.getFree() == (freeMb * 1024) && summary.getUsed() == (usedMb * 1024);
+    }
+
+    private boolean checkLiveSummary(ZGCLiveSummary summary, long markEnd, long relocateStart, long relocateEnd) {
+        return summary.getMarkEnd() == (markEnd * 1024) && summary.getRelocateStart() == (relocateStart *1024) && summary.getRelocateEnd() == (relocateEnd * 1024);
+    }
+
+    private boolean checkAllocatedSummary(ZGCAllocatedSummary summary, long markEnd, long relocateStart, long relocateEnd) {
+        return summary.getMarkEnd() == (markEnd * 1024) && summary.getRelocateStart() == (relocateStart * 1024) && summary.getRelocateEnd() == (relocateEnd * 1024);
+    }
+
+    private boolean checkGarbageSummary(ZGCGarbageSummary summary, long markEnd, long relocateStart, long relocateEnd) {
+        return summary.getMarkEnd() == (markEnd * 1024) && summary.getRelocateStart() == (relocateStart * 1024) && summary.getRelocateEnd() == (relocateEnd * 1024);
+    }
+
+    private boolean checkReclaimSummary(ZGCReclaimSummary summary, long relocateStart, long relocateEnd) {
+        return summary.getReclaimStart() == (relocateStart * 1024) && summary.getReclaimEnd() == (relocateEnd * 1024);
+    }
+
+    private boolean checkPromotedSummary(ZGCPromotedSummary summary, long relocateStart, long relocateEnd) {
+        return summary.getRelocateStart() == (relocateStart * 1024) && summary.getRelocateEnd() == (relocateEnd * 1024);
+    }
+
+    private boolean checkCompactedSummary(ZGCCompactedSummary summary, long relocateEnd) {
+        return summary.getRelocateEnd() == (relocateEnd * 1024);
+    }
+
+    private boolean checkMemorySummary(ZGCMemorySummary summary, long start, long end) {
+        return summary.getStart() == (start * 1024) && summary.getEnd() == (end * 1024);
+    }
+
+    private int toInt(double value, int significantDigits) {
+        return (int)(value * (double)significantDigits);
+    }
+}

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ShenandoahParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ShenandoahParserTest.java
@@ -4,6 +4,9 @@ package com.microsoft.gctoolkit.parser;
 
 import com.microsoft.gctoolkit.event.jvm.JVMEvent;
 import com.microsoft.gctoolkit.event.shenandoah.ShenandoahCycle;
+import com.microsoft.gctoolkit.event.zgc.OccupancySummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCReclaimSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCMemoryPoolSummary;
 import com.microsoft.gctoolkit.jvm.Diarizer;
 import com.microsoft.gctoolkit.parser.jvm.UnifiedDiarizer;
 import org.junit.jupiter.api.Assertions;
@@ -85,5 +88,21 @@ public class ShenandoahParserTest extends ParserTest {
         } catch (Throwable t) {
             Assertions.fail(t);
         }
+    }
+
+    private boolean checkZGCMemoryPoolSummary(ZGCMemoryPoolSummary summary, long capacity, long free, long used) {
+        return summary.getCapacity() == capacity && summary.getFree() == free && summary.getUsed() == used;
+    }
+
+    private boolean checkOccupancySummary(OccupancySummary summary, long markEnd, long relocateStart, long relocateEnd) {
+        return summary.getMarkEnd() == markEnd && summary.getReclaimStart() == relocateStart && summary.getReclaimEnd() == relocateEnd;
+    }
+
+    private boolean checkReclaimSummary(ZGCReclaimSummary summary, long relocateStart, long relocateEnd) {
+        return summary.getReclaimStart() == relocateStart && summary.getReclaimEnd() == relocateEnd;
+    }
+
+    private int toInt(double value, int significantDigits) {
+        return (int)(value * (double)significantDigits);
     }
 }

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserRulesTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserRulesTest.java
@@ -82,7 +82,7 @@ public class ZGCParserRulesTest implements ZGCPatterns {
             MEMORY_TABLE_HEADER,            // 10
             MEMORY_TABLE_ENTRY_SIZE,
             MEMORY_TABLE_ENTRY_OCCUPANCY,
-            MEMORY_TABLE_ENTRY_RECLAIMED,
+            MEMORY_TABLE_ENTRY_RECLAIMED_PROMOTED,
             MEMORY_SUMMARY
     };
 

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
@@ -3,11 +3,14 @@
 package com.microsoft.gctoolkit.parser;
 
 import com.microsoft.gctoolkit.event.jvm.JVMEvent;
-import com.microsoft.gctoolkit.event.zgc.OccupancySummary;
-import com.microsoft.gctoolkit.event.zgc.ReclaimSummary;
-import com.microsoft.gctoolkit.event.zgc.MajorZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.FullZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.ZGCAllocatedSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCGarbageSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCLiveSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCMemoryPoolSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCMemorySummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCMetaspaceSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCReclaimSummary;
 import com.microsoft.gctoolkit.jvm.Diarizer;
 import com.microsoft.gctoolkit.parser.jvm.UnifiedDiarizer;
 import org.junit.jupiter.api.Test;
@@ -72,7 +75,7 @@ public class ZGCParserTest extends ParserTest {
         List<JVMEvent> singleCycle = feedParser(eventLogEntries);
         try {
             assertEquals(1, singleCycle.size());
-            MajorZGCCycle zgc = (MajorZGCCycle) singleCycle.get(0);
+            FullZGCCycle zgc = (FullZGCCycle) singleCycle.get(0);
 
             assertEquals(zgc.getGcId(), 2L);
 
@@ -108,12 +111,12 @@ public class ZGCParserTest extends ParserTest {
 
             assertTrue(checkZGCMetaSpaceSummary(zgc.getMetaspace(),61440, 61440, 1105920));
 
-            assertTrue(checkOccupancySummary(zgc.getLive(), 72704, 72704, 72704));
-            assertTrue(checkOccupancySummary(zgc.getAllocated(), 18432, 20480, 18432));
-            assertTrue(checkOccupancySummary(zgc.getGarbage(), 497664, 456704, 35840));
+            assertTrue(checkLiveSummary(zgc.getLive(), 72704, 72704, 72704));
+            assertTrue(checkAllocatedSummary(zgc.getAllocated(), 18432, 20480, 18432));
+            assertTrue(checkGarbageSummary(zgc.getGarbage(), 497664, 456704, 35840));
 
             assertTrue(checkReclaimSummary(zgc.getReclaimed(), 40960, 460800));
-            assertTrue(checkReclaimSummary(zgc.getMemorySummary(), 571392, 129024));
+            assertTrue(checkMemorySummary(zgc.getMemorySummary(), 571392, 129024));
 
             assertEquals(7.28, zgc.getLoadAverageAt(1));
             assertEquals(6.63, zgc.getLoadAverageAt(5));
@@ -131,178 +134,32 @@ public class ZGCParserTest extends ParserTest {
         }
     }
 
-    @Test
-    public void infoLevelGenerationalZGCCycle() {
-
-        String[] eventLogEntries = {
-                "[4.120s][info][gc          ] GC(0) Major Collection (Metadata GC Threshold)" ,
-                "[4.120s][info][gc,task     ] GC(0) Using 1 Workers for Young Generation" ,
-                "[4.120s][info][gc,task     ] GC(0) Using 1 Workers for Old Generation" ,
-                "[4.120s][info][gc,phases   ] GC(0) Y: Young Generation" ,
-                "[4.120s][info][gc,phases   ] GC(0) Y: Pause Mark Start (Major) 0.066ms" ,
-                "[4.155s][info][gc,phases   ] GC(0) Y: Concurrent Mark 34.619ms" ,
-                "[4.155s][info][gc,phases   ] GC(0) Y: Pause Mark End 0.016ms" ,
-                "[4.155s][info][gc,phases   ] GC(0) Y: Concurrent Mark Free 0.001ms" ,
-                "[4.155s][info][gc,phases   ] GC(0) Y: Concurrent Reset Relocation Set 0.001ms" ,
-                "[4.163s][info][gc,reloc    ] GC(0) Y: Using tenuring threshold: 1 (Computed)" ,
-                "[4.165s][info][gc,phases   ] GC(0) Y: Concurrent Select Relocation Set 10.037ms" ,
-                "[4.165s][info][gc,phases   ] GC(0) Y: Pause Relocate Start 0.014ms" ,
-                "[4.179s][info][gc,phases   ] GC(0) Y: Concurrent Relocate 13.784ms" ,
-                "[4.179s][info][gc,alloc    ] GC(0) Y:                         Mark Start        Mark End      Relocate Start    Relocate End" ,
-                "[4.179s][info][gc,alloc    ] GC(0) Y: Allocation Stalls:          0                0                0                0" ,
-                "[4.179s][info][gc,load     ] GC(0) Y: Load: 9.07 (19%) / 9.48 (20%) / 10.07 (21%)" ,
-                "[4.179s][info][gc,mmu      ] GC(0) Y: MMU: 2ms/96.7%, 5ms/98.7%, 10ms/99.3%, 20ms/99.7%, 50ms/99.8%, 100ms/99.9%" ,
-                "[4.179s][info][gc,marking  ] GC(0) Y: Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s)" ,
-                "[4.179s][info][gc,marking  ] GC(0) Y: Mark Stack Usage: 32M" ,
-                "[4.179s][info][gc,nmethod  ] GC(0) Y: NMethods: 2191 registered, 0 unregistered" ,
-                "[4.179s][info][gc,metaspace] GC(0) Y: Metaspace: 21M used, 21M committed, 1088M reserved" ,
-                "[4.179s][info][gc,reloc    ] GC(0) Y:                        Candidates     Selected     In-Place         Size        Empty    Relocated" ,
-                "[4.179s][info][gc,reloc    ] GC(0) Y: Small Pages:                   49           40            0          98M           0M           6M" ,
-                "[4.179s][info][gc,reloc    ] GC(0) Y: Medium Pages:                   1            0            0          32M           0M           0M" ,
-                "[4.179s][info][gc,reloc    ] GC(0) Y: Large Pages:                    0            0            0           0M           0M           0M" ,
-                "[4.179s][info][gc,reloc    ] GC(0) Y: Forwarding Usage: 2M" ,
-                "[4.179s][info][gc,reloc    ] GC(0) Y: Age Table:" ,
-                "[4.179s][info][gc,reloc    ] GC(0) Y:                    Live             Garbage             Small              Medium             Large" ,
-                "[4.179s][info][gc,reloc    ] GC(0) Y: Eden              16M (1%)          113M (4%)          49 / 40             1 / 0              0 / 0" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y: Min Capacity: 3000M(100%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y: Max Capacity: 3000M(100%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y: Soft Max Capacity: 3000M(100%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y: Heap Statistics:" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y:                Mark Start          Mark End        Relocate Start      Relocate End           High               Low" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y:  Capacity:     3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y:      Free:     2870M (96%)        2866M (96%)        2866M (96%)        2928M (98%)        2934M (98%)        2862M (95%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y:      Used:      130M (4%)          134M (4%)          134M (4%)           72M (2%)          138M (5%)           66M (2%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y: Young Generation Statistics:" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y:                Mark Start          Mark End        Relocate Start      Relocate End" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y:      Used:      130M (4%)          134M (4%)          134M (4%)           72M (2%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y:      Live:         -                16M (1%)           16M (1%)           16M (1%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y:   Garbage:         -               113M (4%)          113M (4%)           32M (1%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y: Allocated:         -                 4M (0%)            4M (0%)           23M (1%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y: Reclaimed:         -                  -                 0M (0%)           81M (3%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y:  Promoted:         -                  -                 0M (0%)            0M (0%)" ,
-                "[4.179s][info][gc,heap     ] GC(0) Y: Compacted:         -                  -                  -                 8M (0%)" ,
-                "[4.179s][info][gc,phases   ] GC(0) Y: Young Generation 130M(4%)->72M(2%) 0.059s" ,
-                "[4.179s][info][gc,phases   ] GC(0) O: Old Generation" ,
-                "[4.182s][info][gc,phases   ] GC(0) O: Concurrent Mark 2.407ms" ,
-                "[4.182s][info][gc,phases   ] GC(0) O: Pause Mark End 0.014ms" ,
-                "[4.182s][info][gc,phases   ] GC(0) O: Concurrent Mark Free 0.009ms" ,
-                "[4.189s][info][gc,phases   ] GC(0) O: Concurrent Process Non-Strong 7.001ms" ,
-                "[4.189s][info][gc,phases   ] GC(0) O: Concurrent Reset Relocation Set 0.001ms" ,
-                "[4.193s][info][gc,phases   ] GC(0) O: Concurrent Select Relocation Set 4.466ms" ,
-                "[4.193s][info][gc,task     ] GC(0) O: Using 1 Workers for Old Generation" ,
-                "[4.218s][info][gc,task     ] GC(0) O: Using 1 Workers for Old Generation" ,
-                "[4.218s][info][gc,phases   ] GC(0) O: Concurrent Remap Roots 24.683ms" ,
-                "[4.220s][info][gc,phases   ] GC(0) O: Pause Relocate Start 0.013ms" ,
-                "[4.220s][info][gc,phases   ] GC(0) O: Concurrent Relocate 0.043ms" ,
-                "[4.220s][info][gc,alloc    ] GC(0) O:                         Mark Start        Mark End      Relocate Start    Relocate End" ,
-                "[4.220s][info][gc,alloc    ] GC(0) O: Allocation Stalls:          0                0                0                0" ,
-                "[4.220s][info][gc,load     ] GC(0) O: Load: 9.07 (19%) / 9.48 (20%) / 10.07 (21%)" ,
-                "[4.220s][info][gc,mmu      ] GC(0) O: MMU: 2ms/96.7%, 5ms/98.7%, 10ms/99.3%, 20ms/99.7%, 50ms/99.8%, 100ms/99.9%" ,
-                "[4.220s][info][gc,marking  ] GC(0) O: Mark: 1 stripe(s), 1 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s)" ,
-                "[4.220s][info][gc,marking  ] GC(0) O: Mark Stack Usage: 0M" ,
-                "[4.220s][info][gc,nmethod  ] GC(0) O: NMethods: 1891 registered, 334 unregistered" ,
-                "[4.220s][info][gc,metaspace] GC(0) O: Metaspace: 22M used, 22M committed, 1088M reserved" ,
-                "[4.220s][info][gc,ref      ] GC(0) O:                       Encountered   Discovered     Enqueued" ,
-                "[4.220s][info][gc,ref      ] GC(0) O: Soft References:             3666            0            0" ,
-                "[4.220s][info][gc,ref      ] GC(0) O: Weak References:             1214            0            0" ,
-                "[4.220s][info][gc,ref      ] GC(0) O: Final References:              19            0            0" ,
-                "[4.220s][info][gc,ref      ] GC(0) O: Phantom References:           767            0            0" ,
-                "[4.220s][info][gc,heap     ] GC(0) O: Min Capacity: 3000M(100%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O: Max Capacity: 3000M(100%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O: Soft Max Capacity: 3000M(100%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O: Heap Statistics:" ,
-                "[4.220s][info][gc,heap     ] GC(0) O:                Mark Start          Mark End        Relocate Start      Relocate End           High               Low" ,
-                "[4.220s][info][gc,heap     ] GC(0) O:  Capacity:     3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)       3000M (100%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O:      Free:     2870M (96%)        2928M (98%)        2926M (98%)        2926M (98%)        2934M (98%)        2862M (95%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O:      Used:      130M (4%)           72M (2%)           74M (2%)           74M (2%)          138M (5%)           66M (2%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O: Old Generation Statistics:" ,
-                "[4.220s][info][gc,heap     ] GC(0) O:                Mark Start          Mark End        Relocate Start      Relocate End" ,
-                "[4.220s][info][gc,heap     ] GC(0) O:      Used:        0M (0%)            0M (0%)            0M (0%)            0M (0%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O:      Live:         -                 0M (0%)            0M (0%)            0M (0%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O:   Garbage:         -                 0M (0%)            0M (0%)            0M (0%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O: Allocated:         -                 0M (0%)            0M (0%)            0M (0%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O: Reclaimed:         -                  -                 0M (0%)            0M (0%)" ,
-                "[4.220s][info][gc,heap     ] GC(0) O: Compacted:         -                  -                  -                 0M (0%)" ,
-                "[4.220s][info][gc,phases   ] GC(0) O: Old Generation 72M(2%)->74M(2%) 0.041s" ,
-                "[4.220s][info][gc          ] GC(0) Major Collection (Metadata GC Threshold) 130M(4%)->74M(2%) 0.100s"
-        };
-
-        List<JVMEvent> singleCycle = feedParser(eventLogEntries);
-        try {
-            assertEquals(1, singleCycle.size());
-            MajorZGCCycle zgc = (MajorZGCCycle) singleCycle.get(0);
-
-            assertEquals(zgc.getGcId(), 0L);
-
-            assertEquals(0.1d, zgc.getDuration(),0.001d);
-            assertEquals(toInt(4.120d, 1000), toInt(zgc.getDateTimeStamp().getTimeStamp(), 1000));
-            assertEquals("Metadata GC Threshold", zgc.getGCCause().getLabel());
-            // Durations
-            assertEquals(4.120d, zgc.getPauseMarkStartTimeStamp().getTimeStamp(),  0.001d);
-            assertEquals(4.120d, zgc.getConcurrentMarkTimeStamp().getTimeStamp(), 0.001d);
-            assertEquals(4.155d, zgc.getConcurrentMarkFreeTimeStamp().getTimeStamp(), 0.001d);
-            assertEquals(4.155d, zgc.getPauseMarkEndTimeStamp().getTimeStamp(), 0.001d);
-            assertEquals(4.182d, zgc.getConcurrentProcessNonStrongReferencesTimeStamp().getTimeStamp(), 0.002d);
-            assertEquals(4.155d, zgc.getConcurrentResetRelocationSetTimeStamp().getTimeStamp(), 0.001d);
-            assertEquals(4.155d, zgc.getConcurrentSelectRelocationSetTimeStamp().getTimeStamp(), 0.001d);
-            assertEquals(4.165d, zgc.getPauseRelocateStartTimeStamp().getTimeStamp(), 0.001d);
-            assertEquals(4.165d, zgc.getConcurrentRelocateTimeStamp().getTimeStamp(), 0.001d);
-
-            assertEquals(0.066d, zgc.getPauseMarkStartDuration(),  0.001);
-            assertEquals(37.026d, zgc.getConcurrentMarkDuration(),  0.001);
-            assertEquals(0.010d, zgc.getConcurrentMarkFreeDuration(),  0.001);
-            assertEquals(0.030, zgc.getPauseMarkEndDuration(),  0.001);
-            assertEquals(7.001d , zgc.getConcurrentProcessNonStrongReferencesDuration(),  0.001);
-            assertEquals(0.002d,zgc.getConcurrentResetRelocationSetDuration(),  0.001);
-            assertEquals(14.503d, zgc.getConcurrentSelectRelocationSetDuration(),  0.001);
-            assertEquals(0.027d, zgc.getPauseRelocateStartDuration(),  0.001);
-            assertEquals(13.827d,zgc.getConcurrentRelocateDuration(),  0.001);
-
-            //Memory
-            assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkStart(), 3072000, 2938880, 133120));
-            assertTrue(checkZGCMemoryPoolSummary(zgc.getMarkEnd(), 3072000, 2998272, 73728 ));
-            assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateStart(),3072000, 2996224, 75776));
-            assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateEnd(), 3072000, 2996224, 75776));
-
-            assertTrue(checkZGCMetaSpaceSummary(zgc.getMetaspace(),22528, 22528, 1114112));
-
-            assertTrue(checkOccupancySummary(zgc.getLive(), 16384, 16384, 16384));
-            assertTrue(checkOccupancySummary(zgc.getAllocated(), 4096, 4096, 23552));
-            assertTrue(checkOccupancySummary(zgc.getGarbage(), 115712, 115712, 32768));
-
-            assertTrue(checkReclaimSummary(zgc.getReclaimed(), 0, 82944));
-            assertTrue(checkReclaimSummary(zgc.getMemorySummary(), 133120, 75776));
-
-            assertEquals(9.07, zgc.getLoadAverageAt(1));
-            assertEquals(9.48, zgc.getLoadAverageAt(5));
-            assertEquals(10.07, zgc.getLoadAverageAt(15));
-
-            assertEquals(96.7, zgc.getMMU(2));
-            assertEquals(98.7, zgc.getMMU(5));
-            assertEquals(99.3, zgc.getMMU(10));
-            assertEquals(99.7, zgc.getMMU(20));
-            assertEquals(99.8, zgc.getMMU(50));
-            assertEquals(99.9, zgc.getMMU(100));
-
-        } catch (Throwable t) {
-            fail(t);
-        }
+    private boolean checkZGCMemoryPoolSummary(ZGCMemoryPoolSummary summary, long capacity, long free, long used) {
+        return summary.getCapacity() == capacity && summary.getFree() == free && summary.getUsed() == used;
     }
 
     private boolean checkZGCMetaSpaceSummary(ZGCMetaspaceSummary summary, long used, long committed, long reserved) {
         return summary.getUsed() == used && summary.getCommitted() == committed && summary.getReserved() == reserved;
     }
 
-    private boolean checkZGCMemoryPoolSummary(ZGCMemoryPoolSummary summary, long capacity, long free, long used) {
-        return summary.getCapacity() == capacity && summary.getFree() == free && summary.getUsed() == used;
+    private boolean checkLiveSummary(ZGCLiveSummary summary, long markEnd, long relocateStart, long relocateEnd) {
+                return summary.getMarkEnd() == markEnd && summary.getRelocateStart() == relocateStart && summary.getRelocateEnd() == relocateEnd;
     }
 
-    private boolean checkOccupancySummary(OccupancySummary summary, long markEnd, long relocateStart, long relocateEnd) {
-        return summary.getMarkEnd() == markEnd && summary.getReclaimStart() == relocateStart && summary.getReclaimEnd() == relocateEnd;
+    private boolean checkAllocatedSummary(ZGCAllocatedSummary summary, long markEnd, long relocateStart, long relocateEnd) {
+        return summary.getMarkEnd() == markEnd && summary.getRelocateStart() == relocateStart && summary.getRelocateEnd() == relocateEnd;
     }
 
-    private boolean checkReclaimSummary(ReclaimSummary summary, long relocateStart, long relocateEnd) {
+    private boolean checkGarbageSummary(ZGCGarbageSummary summary, long markEnd, long relocateStart, long relocateEnd) {
+        return summary.getMarkEnd() == markEnd && summary.getRelocateStart() == relocateStart && summary.getRelocateEnd() == relocateEnd;
+    }
+
+    private boolean checkReclaimSummary(ZGCReclaimSummary summary, long relocateStart, long relocateEnd) {
         return summary.getReclaimStart() == relocateStart && summary.getReclaimEnd() == relocateEnd;
+    }
+
+    private boolean checkMemorySummary(ZGCMemorySummary summary, long relocateStart, long relocateEnd) {
+        return summary.getStart() == relocateStart && summary.getEnd() == relocateEnd;
     }
 
     private int toInt(double value, int significantDigits) {

--- a/sample/src/main/java/com/microsoft/gctoolkit/sample/aggregation/CollectionCycleCountsAggregator.java
+++ b/sample/src/main/java/com/microsoft/gctoolkit/sample/aggregation/CollectionCycleCountsAggregator.java
@@ -7,7 +7,9 @@ import com.microsoft.gctoolkit.event.g1gc.G1GCConcurrentEvent;
 import com.microsoft.gctoolkit.event.g1gc.G1GCPauseEvent;
 import com.microsoft.gctoolkit.event.generational.GenerationalGCPauseEvent;
 import com.microsoft.gctoolkit.event.shenandoah.ShenandoahCycle;
+import com.microsoft.gctoolkit.event.zgc.FullZGCCycle;
 import com.microsoft.gctoolkit.event.zgc.MajorZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.MinorZGCCycle;
 
 @Aggregates({EventSource.G1GC,EventSource.GENERATIONAL,EventSource.ZGC,EventSource.SHENANDOAH})
 public class CollectionCycleCountsAggregator extends Aggregator<CollectionCycleCountsAggregation> {
@@ -17,11 +19,21 @@ public class CollectionCycleCountsAggregator extends Aggregator<CollectionCycleC
         register(GenerationalGCPauseEvent.class, this::count);
         register(G1GCPauseEvent.class, this::count);
         register(G1GCConcurrentEvent.class, this::count);
+        register(FullZGCCycle.class,this::count);
         register(MajorZGCCycle.class,this::count);
+        register(MinorZGCCycle.class,this::count);
         register(ShenandoahCycle.class,this::count);
     }
 
+    private void count(MinorZGCCycle event) {
+        aggregation().count(event.getGarbageCollectionType());
+    }
+
     private void count(MajorZGCCycle event) {
+        aggregation().count(event.getGarbageCollectionType());
+    }
+
+    private void count(FullZGCCycle event) {
         aggregation().count(event.getGarbageCollectionType());
     }
 

--- a/sample/src/main/java/com/microsoft/gctoolkit/sample/aggregation/HeapOccupancyAfterCollection.java
+++ b/sample/src/main/java/com/microsoft/gctoolkit/sample/aggregation/HeapOccupancyAfterCollection.java
@@ -6,7 +6,9 @@ import com.microsoft.gctoolkit.aggregator.EventSource;
 import com.microsoft.gctoolkit.event.g1gc.G1GCPauseEvent;
 import com.microsoft.gctoolkit.event.generational.GenerationalGCPauseEvent;
 import com.microsoft.gctoolkit.event.shenandoah.ShenandoahCycle;
+import com.microsoft.gctoolkit.event.zgc.FullZGCCycle;
 import com.microsoft.gctoolkit.event.zgc.MajorZGCCycle;
+import com.microsoft.gctoolkit.event.zgc.MinorZGCCycle;
 
 @Aggregates({EventSource.G1GC,EventSource.GENERATIONAL,EventSource.ZGC,EventSource.SHENANDOAH})
 public class HeapOccupancyAfterCollection extends Aggregator<HeapOccupancyAfterCollectionAggregation> {
@@ -15,8 +17,18 @@ public class HeapOccupancyAfterCollection extends Aggregator<HeapOccupancyAfterC
         super(results);
         register(GenerationalGCPauseEvent.class, this::extractHeapOccupancy);
         register(G1GCPauseEvent.class, this::extractHeapOccupancy);
+        register(FullZGCCycle.class,this::extractHeapOccupancy);
         register(MajorZGCCycle.class,this::extractHeapOccupancy);
+        register(MinorZGCCycle.class,this::extractHeapOccupancy);
         register(ShenandoahCycle.class,this::extractHeapOccupancy);
+    }
+
+    private void extractHeapOccupancy(MinorZGCCycle event) {
+        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary().getEnd());
+    }
+
+    private void extractHeapOccupancy(MajorZGCCycle event) {
+        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary().getEnd());
     }
 
     private void extractHeapOccupancy(GenerationalGCPauseEvent event) {
@@ -28,11 +40,12 @@ public class HeapOccupancyAfterCollection extends Aggregator<HeapOccupancyAfterC
 
     }
 
-    private void extractHeapOccupancy(MajorZGCCycle event) {
-        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getLive().getReclaimEnd());
+    private void extractHeapOccupancy(FullZGCCycle event) {
+        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getLive().getRelocateEnd());
     }
 
     private void extractHeapOccupancy(ShenandoahCycle event) {
-        // TODO aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getOccupancy());
+        //aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getOccupancy());
     }
 }
+


### PR DESCRIPTION
This patch adds support for generational ZGC and maintains support for legacy (non generational ZGC). There are a number of potential API breaking changes for consumers of GC events. List of changes and modifications are listed below.

1. Introduce new GCEvent types, FullZGCCycle (legacy), MajorZGCCycle and MinorZGCCycle representing the respective types.
2. GCEvents Full/Major/Minor GC Cycles hold reference to internal ZGCCycle, a delegate in the case of Full (legacy) cycle, young and for Major cycle and simply a young for Minor cycle. All cycle types full/young/old, have mostly similar overlapping fields, which allows us to have a single data class for all cycle types. Cycles themselves have a few fields that are specific to entire cycle and are held in the top level object.


```
┌─────────────┐
│    Full     │
│             │      ┌────────┐
│  delegate ──┼─────▶│ZGCCycle│
│             │      └────────┘
└─────────────┘
┌─────────────┐
│    Major    │
│             │      ┌────────┐
│    young ───┼─────▶│ZGCCycle│
│             │      ├────────┤
│     old  ───┼─────▶│ZGCCycle│
└─────────────┘      └────────┘
┌─────────────┐
│    Minor    │
│             │     ┌────────┐
│    young ───┼────▶│ZGCCycle│
│             │     └────────┘
└─────────────┘

```

3.  Add stronger typing on the heap summary report. Live, Garbage, Allocated, Reclaimed, Promoted and Compacted carry information for a different stages of the GC. Each holds a different number of fields. Having a single summary with primitive `double` doesn't make sense as you can't differentiate between 0 and not present. We could use optional or boxed type but it seemed more direct to declare a type. In future java versions these could simply be Record classes.
4. Added concept of phase to the ZGC Parsers. The phase represents whether the GC cycle is in Major young/old, Minor young or Full phase (legacy). This maps to the GC output of `Y`, `y`, `O` prefix on the log line. We key off this to make a determination about which heap statistics we are writing to. Phase is determined by an optional capture group at the head of all log lines.
5. Introduced new hierarchical forward reference type to allow it to cary more contextual information about either young or old generation. Major obviously has two references, one for old and one for young. Minor and full GC's cary a single forward ref corresponding to their cycle.
6. Added new ZGC generational test for both Minor and Major cycle types ensuring that both are parsed correctly.