### PR TITLE
bump vertx-core version

### DIFF
--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>4.5.11</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Moves io.netty to 4.1.118.Final in order to address CVE-2025-24970 and CVE-2025-25193 which are present in version 4.1.115.Final. This has an impact on component governance for downstream projects. 