### PR TITLE
fix jreleaser issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,6 @@
                                 </upload>
                                 <release>
                                     <github>
-                                        <tagName>gctoolkit-{{projectVersion}}</tagName>
                                         <skipTag>true</skipTag>
                                         <overwrite>true</overwrite>
                                         <changelog>


### PR DESCRIPTION
`<tagName>gctoolkit-{{projectVersion}}</tagName>` in the `<github>` section of the jreleaser spec somehow causes the changelog to be empty. 