### PR TITLE
Change ZGC start tag

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
@@ -15,7 +15,7 @@ public interface ZGCPatterns extends UnifiedPatterns {
 
     String MEMORY_PERCENT = GenericTokens.INT + GenericTokens.UNITS + "\\s*\\(" + GenericTokens.INT + "%\\)";
 
-    GCParseRule ZGC_TAG = new GCParseRule("ZGC Tag", "Initializing The Z Garbage Collector$");
+    GCParseRule ZGC_TAG = new GCParseRule("ZGC Tag", "Using The Z Garbage Collector$");
 
     //[3.558s][info ][gc,start       ] GC(3) Garbage Collection (Warmup)
     GCParseRule CYCLE_START = new GCParseRule("CYCLE_START", "GC\\(" + GenericTokens.INT + "\\) (Garbage|Major|Minor) Collection " + GenericTokens.GC_CAUSE + "$");


### PR DESCRIPTION
This change allows us to detect a ZGC log when only using `-Xlog:gc`. The old tag required `gc+init=info`. This should improve log detection. This should help fixes #382


Old detection using:
```
[info][gc,init] Initializing The Z Garbage Collector
```

New detection using:
```
[info][gc     ] Using The Z Garbage Collector
```