### PR TITLE
Move stdout direct logging under debug mode

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogTrace.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogTrace.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 package com.microsoft.gctoolkit.parser;
 
+import com.microsoft.gctoolkit.GCToolKit;
 import com.microsoft.gctoolkit.event.GCCause;
 import com.microsoft.gctoolkit.event.GCCauses;
 import com.microsoft.gctoolkit.event.MemoryPoolSummary;
@@ -28,7 +29,6 @@ public class GCLogTrace extends AbstractLogTrace {
     private static final Logger LOGGER = Logger.getLogger(GCLogTrace.class.getName());
 
     private final boolean gcCauseDebugging = Boolean.getBoolean("microsoft.debug.gccause");
-    private final boolean debugging = Boolean.getBoolean("microsoft.debug");
 
     public GCLogTrace(Matcher matcher) {
         super(matcher);
@@ -292,15 +292,16 @@ public class GCLogTrace extends AbstractLogTrace {
             LOGGER.log(Level.FINE, "{0} : {1}", new Object[]{i, getGroup(i)});
         }
         LOGGER.fine("-----------------------------------------");
-        //IntelliJ Eats this log output so it's displayed to stdout..
-        //And yes, that means System.out.println is in here in on purpose
-        if (debugging) {
-            System.out.println(threadName + ", not implemented: " + getGroup(0));
+        //IntelliJ Eats this log output, so it's displayed to stdout
+        GCToolKit.LOG_DEBUG_MESSAGE(() -> {
+            StringBuilder debugMessage = new StringBuilder();
+            debugMessage.append(threadName).append(", not implemented: ").append(getGroup(0)).append(System.lineSeparator());
             for (int i = 1; i < groupCount() + 1; i++) {
-                System.out.println(i + ": " + getGroup(i));
+                debugMessage.append(i).append(": ").append(getGroup(i)).append(System.lineSeparator());
             }
-            System.out.println("-----------------------------------------");
-        }
+            debugMessage.append("-----------------------------------------");
+            return debugMessage.toString();
+        });
     }
 
     public ZGCPhase getZCollectionPhase() {

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogTrace.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GCLogTrace.java
@@ -28,7 +28,7 @@ public class GCLogTrace extends AbstractLogTrace {
     private static final Logger LOGGER = Logger.getLogger(GCLogTrace.class.getName());
 
     private final boolean gcCauseDebugging = Boolean.getBoolean("microsoft.debug.gccause");
-    // private final boolean debugging = Boolean.getBoolean("microsoft.debug");
+    private final boolean debugging = Boolean.getBoolean("microsoft.debug");
 
     public GCLogTrace(Matcher matcher) {
         super(matcher);
@@ -294,13 +294,13 @@ public class GCLogTrace extends AbstractLogTrace {
         LOGGER.fine("-----------------------------------------");
         //IntelliJ Eats this log output so it's displayed to stdout..
         //And yes, that means System.out.println is in here in on purpose
-        //if ( debugging) {
-        System.out.println(threadName + ", not implemented: " + getGroup(0));
-        for (int i = 1; i < groupCount() + 1; i++) {
-            System.out.println(i + ": " + getGroup(i));
+        if (debugging) {
+            System.out.println(threadName + ", not implemented: " + getGroup(0));
+            for (int i = 1; i < groupCount() + 1; i++) {
+                System.out.println(i + ": " + getGroup(i));
+            }
+            System.out.println("-----------------------------------------");
         }
-        System.out.println("-----------------------------------------");
-        //}
     }
 
     public ZGCPhase getZCollectionPhase() {


### PR DESCRIPTION
This direct logging via System.out.println in non-debug mode causes noice in the console output for the tool using gctoolkit. Discussion: [421](https://github.com/microsoft/gctoolkit/issues/421)