### PR TITLE
Ensure FullZGCCycle has all delegate methods

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
@@ -10,28 +10,153 @@ import com.microsoft.gctoolkit.time.DateTimeStamp;
 public class FullZGCCycle extends GCEvent {
     private ZGCCycle delegate;
 
-    public FullZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, GCCause cause, double duration) {
+    public FullZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, GCCause cause, double duration, ZGCCycle delegate) {
         super(timeStamp, gcType, cause, duration);
-    }
-
-    public FullZGCCycle(DateTimeStamp timeStamp, double duration) {
-        super(timeStamp, duration);
-    }
-
-    public FullZGCCycle(DateTimeStamp timeStamp, GCCause cause, double duration) {
-        super(timeStamp, cause, duration);
-    }
-
-    public FullZGCCycle(DateTimeStamp timeStamp, GarbageCollectionTypes gcType, double duration) {
-        super(timeStamp, gcType, duration);
+        this.delegate = delegate;
     }
 
     public void setZGCCycle(ZGCCycle zgcCycle) {
         this.delegate = zgcCycle;
     }
 
+    public ZGCReferenceSummary getSoftRefSummary() {
+        return delegate.getSoftRefSummary();
+    }
+
+    public ZGCReferenceSummary getFinalRefSummary() {
+        return delegate.getFinalRefSummary();
+    }
+
+    public ZGCMemoryPoolSummary getMarkEnd() {
+        return delegate.getMarkEnd();
+    }
+
+    public DateTimeStamp getConcurrentRemapRootsStart() {
+        return delegate.getConcurrentRemapRootsStart();
+    }
+
+    public DateTimeStamp getRemapRememberedStart() {
+        return delegate.getRemapRememberedStart();
+    }
+
+    public ZGCPromotedSummary getPromotedSummary() {
+        return delegate.getPromotedSummary();
+    }
+
+    public ZGCMetaspaceSummary getMetaspaceSummary() {
+        return delegate.getMetaspaceSummary();
+    }
+
+    public ZGCReferenceSummary getWeakRefSummary() {
+        return delegate.getWeakRefSummary();
+    }
+
+    public DateTimeStamp getConcurrentSelectRelocationSetTimeStamp() {
+        return delegate.getConcurrentSelectRelocationSetTimeStamp();
+    }
+
+    public DateTimeStamp getRemapRootColoredStart() {
+        return delegate.getRemapRootColoredStart();
+    }
+
+    public ZGCPhase getPhase() {
+        return delegate.getPhase();
+    }
+
+    public double getRemapRootsColoredDuration() {
+        return delegate.getRemapRootsColoredDuration();
+    }
+
+    public double getConcurrentMarkContinueDuration() {
+        return delegate.getConcurrentMarkContinueDuration();
+    }
+
+    public double getConcurrentRemapRootsDuration() {
+        return delegate.getConcurrentRemapRootsDuration();
+    }
+
+    public double getPauseMarkRelocateDuration() {
+        return delegate.getPauseMarkRelocateDuration();
+    }
+
+    public ZGCAllocatedSummary getAllocatedSummary() {
+        return delegate.getAllocatedSummary();
+    }
+
+    public ZGCReferenceSummary getPhantomRefSummary() {
+        return delegate.getPhantomRefSummary();
+    }
+
     public ZGCMarkSummary getMarkSummary() {
         return delegate.getMarkSummary();
+    }
+
+    public double getRemapRememberedDuration() {
+        return delegate.getRemapRememberedDuration();
+    }
+
+    public ZGCGarbageSummary getGarbageSummary() {
+        return delegate.getGarbageSummary();
+    }
+
+    public DateTimeStamp getConcurrentResetRelocationSetTimeStamp() {
+        return delegate.getConcurrentResetRelocationSetTimeStamp();
+    }
+
+    public double getConcurrentMarkFreeDuration() {
+        return delegate.getConcurrentMarkFreeDuration();
+    }
+
+    public ZGCMemoryPoolSummary getMarkStart() {
+        return delegate.getMarkStart();
+    }
+
+    public ZGCLiveSummary getLiveSummary() {
+        return delegate.getLiveSummary();
+    }
+
+    public DateTimeStamp getConcurrentProcessNonStrongReferencesTimeStamp() {
+        return delegate.getConcurrentProcessNonStrongReferencesTimeStamp();
+    }
+
+    public DateTimeStamp getConcurrentMarkContinueTimeStamp() {
+        return delegate.getConcurrentMarkContinueTimeStamp();
+    }
+
+    public ZGCCollectionType getType() {
+        return delegate.getType();
+    }
+
+    public ZGCMemoryPoolSummary getRelocateStart() {
+        return delegate.getRelocateStart();
+    }
+
+    public DateTimeStamp getMarkFollowStart() {
+        return delegate.getMarkFollowStart();
+    }
+
+    public double getPauseMarkEndDuration() {
+        return delegate.getPauseMarkEndDuration();
+    }
+
+    public double getConcurrentSelectRelocationSetDuration() {
+        return delegate.getConcurrentSelectRelocationSetDuration();
+    }
+
+    public double getMarkRootsDuration() {
+        return delegate.getMarkRootsDuration();
+    }
+
+    public double[] getMmu() {
+        return delegate.getMmu();
+    }
+
+    public double getConcurrentProcessNonStrongReferencesDuration() {
+        return delegate.getConcurrentProcessNonStrongReferencesDuration();
+    }
+
+    public DateTimeStamp getConcurrentRelocateTimeStamp() {
+        return delegate.getConcurrentRelocateTimeStamp();
     }
 
     public DateTimeStamp getPauseMarkStartTimeStamp() {
@@ -42,206 +167,88 @@ public class FullZGCCycle extends GCEvent {
         return delegate.getPauseMarkStartDuration();
     }
 
-    public long getGcId() {
-        return delegate.getGcId();
+    public OccupancySummary getUsedOccupancySummary() {
+        return delegate.getUsedOccupancySummary();
     }
-
 
     public DateTimeStamp getConcurrentMarkTimeStamp() {
         return delegate.getConcurrentMarkTimeStamp();
-    }
-
-    public double getConcurrentMarkDuration() {
-        return delegate.getConcurrentMarkDuration();
-    }
-
-    public DateTimeStamp getConcurrentMarkFreeTimeStamp() {
-        return delegate.getConcurrentMarkFreeTimeStamp();
-    }
-
-    public double getConcurrentMarkFreeDuration() {
-        return delegate.getConcurrentMarkFreeDuration();
-    }
-
-    public DateTimeStamp getPauseMarkEndTimeStamp() {
-        return delegate.getPauseMarkEndTimeStamp();
-    }
-
-    public double getPauseMarkEndDuration() {
-        return delegate.getPauseMarkEndDuration();
-    }
-
-
-    public DateTimeStamp getConcurrentProcessNonStrongReferencesTimeStamp() {
-        return delegate.getConcurrentProcessNonStrongReferencesTimeStamp();
-    }
-
-    public double getConcurrentProcessNonStrongReferencesDuration() {
-        return delegate.getConcurrentProcessNonStrongReferencesDuration();
-    }
-
-    public DateTimeStamp getConcurrentResetRelocationSetTimeStamp() {
-        return delegate.getConcurrentResetRelocationSetTimeStamp();
-    }
-
-    public double getConcurrentResetRelocationSetDuration() {
-        return delegate.getConcurrentResetRelocationSetDuration();
-    }
-
-    public DateTimeStamp getConcurrentSelectRelocationSetTimeStamp() {
-        return delegate.getConcurrentSelectRelocationSetTimeStamp();
-    }
-
-    public double getConcurrentSelectRelocationSetDuration() {
-        return delegate.getConcurrentSelectRelocationSetDuration();
-    }
-
-    public DateTimeStamp getPauseRelocateStartTimeStamp() {
-        return delegate.getPauseRelocateStartTimeStamp();
-    }
-
-    public double getPauseRelocateStartDuration() {
-        return delegate.getPauseRelocateStartDuration();
-    }
-
-    public DateTimeStamp getConcurrentRelocateTimeStamp() {
-        return delegate.getConcurrentRelocateTimeStamp();
-    }
-
-    public double getConcurrentRelocateDuration() {
-        return delegate.getConcurrentRelocateDuration();
-    }
-
-    public ZGCMemoryPoolSummary getMarkStart() {
-        return delegate.getMarkStart();
-    }
-
-    public ZGCMemoryPoolSummary getMarkEnd() {
-        return delegate.getMarkEnd();
-    }
-
-    public ZGCMemoryPoolSummary getRelocateStart() {
-        return delegate.getRelocateStart();
-    }
-
-    public ZGCMemoryPoolSummary getRelocateEnd() {
-        return delegate.getRelocateEnd();
-    }
-
-    public ZGCLiveSummary getLive() {
-        return delegate.getLiveSummary();
-    }
-
-    public ZGCAllocatedSummary getAllocated() {
-        return delegate.getAllocatedSummary();
-    }
-
-    public ZGCGarbageSummary getGarbage() {
-        return delegate.getGarbageSummary();
-    }
-
-    public ZGCReclaimSummary getReclaimed() {
-        return delegate.getReclaimSummary();
-    }
-
-    public ZGCMemorySummary getMemorySummary() {
-        return delegate.getMemorySummary();
-    }
-
-    public ZGCMetaspaceSummary getMetaspace() {
-        return delegate.getMetaspaceSummary();
-    }
-
-    public double getLoadAverageAt(int time) {
-        return delegate.getLoadAverageAt(time);
     }
 
     public double getMMU(int percentage) {
         return delegate.getMMU(percentage);
     }
 
-    public ZGCPromotedSummary getPromotedSummary() {
-        return delegate.getPromotedSummary();
+    public ZGCMemorySummary getMemorySummary() {
+        return delegate.getMemorySummary();
     }
 
     public ZGCCompactedSummary getCompactedSummary() {
         return delegate.getCompactedSummary();
     }
 
-    public OccupancySummary getUsedOccupancySummary() {
-        return delegate.getUsedOccupancySummary();
+    public long getGcId() {
+        return delegate.getGcId();
     }
 
-    public ZGCCollectionType getType() {
-        return delegate.getType();
+    public double getConcurrentResetRelocationSetDuration() {
+        return delegate.getConcurrentResetRelocationSetDuration();
     }
 
-    public DateTimeStamp getMarkRootsStart() {
-        return delegate.getMarkRootsStart();
+    public DateTimeStamp getConcurrentMarkFreeTimeStamp() {
+        return delegate.getConcurrentMarkFreeTimeStamp();
     }
 
-    public double getMarkRootsDuration() {
-        return delegate.getMarkRootsDuration();
+    public DateTimeStamp getPauseMarkEndTimeStamp() {
+        return delegate.getPauseMarkEndTimeStamp();
     }
 
-    public DateTimeStamp getMarkFollowStart() {
-        return delegate.getMarkFollowStart();
+    public double getConcurrentRelocateDuration() {
+        return delegate.getConcurrentRelocateDuration();
     }
 
-    public double getMarkFollowDuration() {
-        return delegate.getMarkFollowDuration();
+    public double getLoadAverageAt(int time) {
+        return delegate.getLoadAverageAt(time);
     }
 
-    public DateTimeStamp getRemapRootColoredStart() {
-        return delegate.getRemapRootColoredStart();
-    }
-
-    public double getRemapRootsColoredDuration() {
-        return delegate.getRemapRootsColoredDuration();
-    }
-
-    public DateTimeStamp getRemapRootsUncoloredStart() {
-        return delegate.getRemapRootsUncoloredStart();
-    }
-
-    public double getRemapRootsUncoloredDuration() {
-        return delegate.getRemapRootsUncoloredDuration();
-    }
-
-    public DateTimeStamp getRemapRememberedStart() {
-        return delegate.getRemapRememberedStart();
-    }
-
-    public double getRemapRememberedDuration() {
-        return delegate.getRemapRememberedDuration();
-    }
-
-    public double getPauseMarkRelocateDuration() {
-        return delegate.getPauseMarkRelocateDuration();
-    }
-
-    public DateTimeStamp getConcurrentMarkContinueTimeStamp() {
-        return delegate.getConcurrentMarkContinueTimeStamp();
-    }
-
-    public double getConcurrentMarkContinueDuration() {
-        return delegate.getConcurrentMarkContinueDuration();
-    }
-
-    public DateTimeStamp getRemapRootsStart() {
-        return delegate.getConcurrentRemapRootsStart();
-    }
-
-    public double getRemapRootsDuration() {
-        return delegate.getConcurrentRemapRootsDuration();
+    public DateTimeStamp getPauseRelocateStartTimeStamp() {
+        return delegate.getPauseRelocateStartTimeStamp();
     }
 
     public double[] getLoad() {
         return delegate.getLoad();
     }
 
-    public double[] getMmu() {
-        return delegate.getMmu();
+    public double getPauseRelocateStartDuration() {
+        return delegate.getPauseRelocateStartDuration();
+    }
+
+    public DateTimeStamp getRemapRootsUncoloredStart() {
+        return delegate.getRemapRootsUncoloredStart();
+    }
+
+    public DateTimeStamp getMarkRootsStart() {
+        return delegate.getMarkRootsStart();
+    }
+
+    public double getRemapRootsUncoloredDuration() {
+        return delegate.getRemapRootsUncoloredDuration();
+    }
+
+    public double getConcurrentMarkDuration() {
+        return delegate.getConcurrentMarkDuration();
+    }
+
+    public ZGCReclaimSummary getReclaimSummary() {
+        return delegate.getReclaimSummary();
+    }
+
+    public double getMarkFollowDuration() {
+        return delegate.getMarkFollowDuration();
+    }
+
+    public ZGCMemoryPoolSummary getRelocateEnd() {
+        return delegate.getRelocateEnd();
     }
 }
 

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
@@ -718,13 +718,12 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
 
             // Duration recorded by GC
             FullZGCCycle fullZGCCycle;
+            ZGCCycle delegate = getZGCCycle(endTime);
             if (gcDuration != null){
-                fullZGCCycle = new FullZGCCycle(startTimeStamp, gcType, gcCause, gcDuration);
+                fullZGCCycle = new FullZGCCycle(startTimeStamp, gcType, gcCause, gcDuration, delegate);
             } else {
-                fullZGCCycle = new FullZGCCycle(startTimeStamp, gcType, gcCause, endTime.minus(startTimeStamp));
+                fullZGCCycle = new FullZGCCycle(startTimeStamp, gcType, gcCause, endTime.minus(startTimeStamp), delegate);
             }
-
-            fullZGCCycle.setZGCCycle(getZGCCycle(endTime));
 
             return fullZGCCycle;
         }

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/ZGCParserTest.java
@@ -109,13 +109,13 @@ public class ZGCParserTest extends ParserTest {
             assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateStart(),1837056, 28823552, 550912));
             assertTrue(checkZGCMemoryPoolSummary(zgc.getRelocateEnd(), 1837056, 29245440, 129024));
 
-            assertTrue(checkZGCMetaSpaceSummary(zgc.getMetaspace(),61440, 61440, 1105920));
+            assertTrue(checkZGCMetaSpaceSummary(zgc.getMetaspaceSummary(),61440, 61440, 1105920));
 
-            assertTrue(checkLiveSummary(zgc.getLive(), 72704, 72704, 72704));
-            assertTrue(checkAllocatedSummary(zgc.getAllocated(), 18432, 20480, 18432));
-            assertTrue(checkGarbageSummary(zgc.getGarbage(), 497664, 456704, 35840));
+            assertTrue(checkLiveSummary(zgc.getLiveSummary(), 72704, 72704, 72704));
+            assertTrue(checkAllocatedSummary(zgc.getAllocatedSummary(), 18432, 20480, 18432));
+            assertTrue(checkGarbageSummary(zgc.getGarbageSummary(), 497664, 456704, 35840));
 
-            assertTrue(checkReclaimSummary(zgc.getReclaimed(), 40960, 460800));
+            assertTrue(checkReclaimSummary(zgc.getReclaimSummary(), 40960, 460800));
             assertTrue(checkMemorySummary(zgc.getMemorySummary(), 571392, 129024));
 
             assertEquals(7.28, zgc.getLoadAverageAt(1));

--- a/sample/src/main/java/com/microsoft/gctoolkit/sample/aggregation/HeapOccupancyAfterCollection.java
+++ b/sample/src/main/java/com/microsoft/gctoolkit/sample/aggregation/HeapOccupancyAfterCollection.java
@@ -41,7 +41,7 @@ public class HeapOccupancyAfterCollection extends Aggregator<HeapOccupancyAfterC
     }
 
     private void extractHeapOccupancy(FullZGCCycle event) {
-        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getLive().getRelocateEnd());
+        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary().getOccupancyAfter());
     }
 
     private void extractHeapOccupancy(ShenandoahCycle event) {


### PR DESCRIPTION
FullZGCCycle delegates it's accessors to underlying ZGCCycle class. The FullZGCCycle was missing some delegate accessor methods missed during a previous refactor. This change ensures that all "getter" methods are exposed from the FullZGCCycle. These were regenerated automatically by intellij hence the reformatting and reordering of methods.