### PR TITLE
[ZGC] Add support for heap capacity, nMethod and relocation summary

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
@@ -254,6 +254,10 @@ public class FullZGCCycle extends GCEvent {
     public ZGCHeapCapacitySummary getHeapCapacitySummary() {
         return delegate.getHeapCapacitySummary();
     }
+
+    public ZGCNMethodSummary getNMethodSummary() {
+        return delegate.getNMethodSummary();
+    }
 }
 
 // Concurrent Mark duration

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
@@ -250,6 +250,10 @@ public class FullZGCCycle extends GCEvent {
     public ZGCMemoryPoolSummary getRelocateEnd() {
         return delegate.getRelocateEnd();
     }
+
+    public ZGCHeapCapacitySummary getHeapCapacitySummary() {
+        return delegate.getHeapCapacitySummary();
+    }
 }
 
 // Concurrent Mark duration

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/FullZGCCycle.java
@@ -7,6 +7,8 @@ import com.microsoft.gctoolkit.event.GCEvent;
 import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
+import java.util.List;
+
 public class FullZGCCycle extends GCEvent {
     private ZGCCycle delegate;
 
@@ -257,6 +259,26 @@ public class FullZGCCycle extends GCEvent {
 
     public ZGCNMethodSummary getNMethodSummary() {
         return delegate.getNMethodSummary();
+    }
+
+    public ZGCPageSummary getSmallPageSummary() {
+        return delegate.getSmallPageSummary();
+    }
+
+    public ZGCPageSummary getMediumPageSummary() {
+        return delegate.getMediumPageSummary();
+    }
+
+    public ZGCPageSummary getLargePageSummary() {
+        return delegate.getLargePageSummary();
+    }
+
+    public long getForwardingUsage() {
+        return delegate.getForwardingUsage();
+    }
+
+    public List<ZGCPageAgeSummary> getAgeTableSummary() {
+        return delegate.getAgeTableSummary();
     }
 }
 

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
@@ -57,6 +57,7 @@ public class ZGCCycle {
     private ZGCReclaimSummary reclaimSummary;
     private ZGCMemorySummary memorySummary;
     private ZGCMetaspaceSummary metaspaceSummary;
+    private ZGCHeapCapacitySummary heapCapacitySummary;
 
     public ZGCReferenceSummary getSoftRefSummary() {
         return softRefSummary;
@@ -492,5 +493,13 @@ public class ZGCCycle {
 
     public void setPhantomRefSummary(ZGCReferenceSummary phantomRefSummary) {
         this.phantomRefSummary = phantomRefSummary;
+    }
+
+    public void setHeapCapacitySummary(ZGCHeapCapacitySummary heapCapacitySummary) {
+        this.heapCapacitySummary = heapCapacitySummary;
+    }
+
+    public ZGCHeapCapacitySummary getHeapCapacitySummary() {
+        return heapCapacitySummary;
     }
 }

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
@@ -2,6 +2,8 @@ package com.microsoft.gctoolkit.event.zgc;
 
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
+import java.util.List;
+
 public class ZGCCycle {
     private DateTimeStamp markRootsStart;
     private double markRootsDuration;
@@ -59,6 +61,12 @@ public class ZGCCycle {
     private ZGCMetaspaceSummary metaspaceSummary;
     private ZGCHeapCapacitySummary heapCapacitySummary;
     private ZGCNMethodSummary nMethodSummary;
+
+    private ZGCPageSummary smallPageSummary;
+    private ZGCPageSummary mediumPageSummary;
+    private ZGCPageSummary largePageSummary;
+    private long forwardingUsage;
+    private List<ZGCPageAgeSummary> ageTableSummary;
 
     public ZGCReferenceSummary getSoftRefSummary() {
         return softRefSummary;
@@ -510,5 +518,45 @@ public class ZGCCycle {
 
     public ZGCNMethodSummary getNMethodSummary() {
         return nMethodSummary;
+    }
+
+    public void setSmallPageSummary(ZGCPageSummary smallPageSummary) {
+        this.smallPageSummary = smallPageSummary;
+    }
+
+    public void setMediumPageSummary(ZGCPageSummary mediumPageSummary) {
+        this.mediumPageSummary = mediumPageSummary;
+    }
+
+    public void setLargePageSummary(ZGCPageSummary largePageSummary) {
+        this.largePageSummary = largePageSummary;
+    }
+
+    public ZGCPageSummary getSmallPageSummary() {
+        return smallPageSummary;
+    }
+
+    public ZGCPageSummary getMediumPageSummary() {
+        return mediumPageSummary;
+    }
+
+    public ZGCPageSummary getLargePageSummary() {
+        return largePageSummary;
+    }
+
+    public void setForwardingUsage(long forwardingUsage) {
+        this.forwardingUsage = forwardingUsage;
+    }
+
+    public long getForwardingUsage() {
+        return forwardingUsage;
+    }
+
+    public void setAgeTableSummary(List<ZGCPageAgeSummary> ageTableSummary) {
+        this.ageTableSummary = ageTableSummary;
+    }
+
+    public List<ZGCPageAgeSummary> getAgeTableSummary() {
+        return ageTableSummary;
     }
 }

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCCycle.java
@@ -58,6 +58,7 @@ public class ZGCCycle {
     private ZGCMemorySummary memorySummary;
     private ZGCMetaspaceSummary metaspaceSummary;
     private ZGCHeapCapacitySummary heapCapacitySummary;
+    private ZGCNMethodSummary nMethodSummary;
 
     public ZGCReferenceSummary getSoftRefSummary() {
         return softRefSummary;
@@ -501,5 +502,13 @@ public class ZGCCycle {
 
     public ZGCHeapCapacitySummary getHeapCapacitySummary() {
         return heapCapacitySummary;
+    }
+
+    public void setNMethodSummary(ZGCNMethodSummary nMethodSummary) {
+        this.nMethodSummary = nMethodSummary;
+    }
+
+    public ZGCNMethodSummary getNMethodSummary() {
+        return nMethodSummary;
     }
 }

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCHeapCapacitySummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCHeapCapacitySummary.java
@@ -1,0 +1,25 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCHeapCapacitySummary {
+    private final long minCapacity;
+    private final long maxCapacity;
+    private final long softMaxCapacity;
+
+    public ZGCHeapCapacitySummary(long minCapacity, long maxCapacity, long softMaxCapacity) {
+        this.minCapacity = minCapacity;
+        this.maxCapacity = maxCapacity;
+        this.softMaxCapacity = softMaxCapacity;
+    }
+
+    public long getMinCapacity() {
+        return minCapacity;
+    }
+
+    public long getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    public long getSoftMaxCapacity() {
+        return softMaxCapacity;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCNMethodSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCNMethodSummary.java
@@ -1,0 +1,19 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCNMethodSummary {
+    private final long registered;
+    private final long unregistered;
+
+    public ZGCNMethodSummary(long registered, long unregistered) {
+        this.registered = registered;
+        this.unregistered = unregistered;
+    }
+
+    public long getUnregistered() {
+        return unregistered;
+    }
+
+    public long getRegistered() {
+        return registered;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCPageAgeSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCPageAgeSummary.java
@@ -1,0 +1,84 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCPageAgeSummary {
+    private final String name;
+    private final long live;
+    private final int livePct;
+    private final long garbage;
+    private final int garbagePct;
+    private final long smallPageCandidates;
+    private final long smallPageSelected;
+    private final long mediumPageCandidates;
+    private final long mediumPageSelected;
+    private final long largePageCandidates;
+    private final long largePageSelected;
+
+    public ZGCPageAgeSummary(
+            String name,
+            long live,
+            int livePct,
+            long garbage,
+            int garbagePct,
+            long smallPageCandidates,
+            long smallPageSelected,
+            long mediumPageCandidates,
+            long mediumPageSelected,
+            long largePageCandidates,
+            long largePageSelected) {
+        this.name = name;
+        this.live = live;
+        this.livePct = livePct;
+        this.garbage = garbage;
+        this.garbagePct = garbagePct;
+        this.smallPageCandidates = smallPageCandidates;
+        this.smallPageSelected = smallPageSelected;
+        this.mediumPageCandidates = mediumPageCandidates;
+        this.mediumPageSelected = mediumPageSelected;
+        this.largePageCandidates = largePageCandidates;
+        this.largePageSelected = largePageSelected;
+    }
+
+    public long getGarbage() {
+        return garbage;
+    }
+
+    public int getGarbagePct() {
+        return garbagePct;
+    }
+
+    public long getLargePageCandidates() {
+        return largePageCandidates;
+    }
+
+    public long getLargePageSelected() {
+        return largePageSelected;
+    }
+
+    public long getLive() {
+        return live;
+    }
+
+    public int getLivePct() {
+        return livePct;
+    }
+
+    public long getMediumPageCandidates() {
+        return mediumPageCandidates;
+    }
+
+    public long getMediumPageSelected() {
+        return mediumPageSelected;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public long getSmallPageCandidates() {
+        return smallPageCandidates;
+    }
+
+    public long getSmallPageSelected() {
+        return smallPageSelected;
+    }
+}

--- a/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCPageSummary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/zgc/ZGCPageSummary.java
@@ -1,0 +1,43 @@
+package com.microsoft.gctoolkit.event.zgc;
+
+public class ZGCPageSummary {
+    private final long candidates;
+    private final long selected;
+    private final long inPlace;
+    private final long size;
+    private final long empty;
+    private final long relocated;
+
+    public ZGCPageSummary(long candidates, long selected, long inPlace, long size, long empty, long relocated) {
+        this.candidates = candidates;
+        this.selected = selected;
+        this.inPlace = inPlace;
+        this.size = size;
+        this.empty = empty;
+        this.relocated = relocated;
+    }
+
+    public long getCandidates() {
+        return candidates;
+    }
+
+    public long getEmpty() {
+        return empty;
+    }
+
+    public long getInPlace() {
+        return inPlace;
+    }
+
+    public long getRelocated() {
+        return relocated;
+    }
+
+    public long getSelected() {
+        return selected;
+    }
+
+    public long getSize() {
+        return size;
+    }
+}

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/ZGCParser.java
@@ -18,6 +18,7 @@ import com.microsoft.gctoolkit.event.zgc.ZGCLiveSummary;
 import com.microsoft.gctoolkit.event.zgc.MajorZGCCycle;
 import com.microsoft.gctoolkit.event.zgc.OccupancySummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCCompactedSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCNMethodSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCPhase;
 import com.microsoft.gctoolkit.event.zgc.ZGCPromotedSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCReclaimSummary;
@@ -319,7 +320,12 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
     }
 
     private void nMethods(GCLogTrace trace, String s) {
-        //trace.notYetImplemented();
+        ZGCForwardReference ref = getForwardRefForPhase(trace.getZCollectionPhase());
+
+        ZGCNMethodSummary summary = new ZGCNMethodSummary(
+                trace.getLongGroup(2),
+                trace.getLongGroup(3));
+        ref.setNMethodSummary(summary);
     }
 
     private void metaspace(GCLogTrace trace, String s) {
@@ -713,6 +719,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
         private ZGCReferenceSummary weakRefSummary;
         private ZGCReferenceSummary finalRefSummary;
         private ZGCReferenceSummary phantomRefSummary;
+        private ZGCNMethodSummary nMethodSummary;
 
         public ZGCForwardReference(DateTimeStamp dateTimeStamp, long gcId, GCCause cause, ZGCCollectionType type, ZGCPhase phase) {
             this.startTimeStamp = dateTimeStamp;
@@ -793,6 +800,7 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
             cycle.setLoadAverages(load);
             cycle.setMMU(mmu);
             cycle.setMarkSummary(markSummary);
+            cycle.setNMethodSummary(nMethodSummary);
             return cycle;
         }
 
@@ -1029,6 +1037,10 @@ public class ZGCParser extends UnifiedGCLogParser implements ZGCPatterns {
 
         public void setHeapCapacitySummary(ZGCHeapCapacitySummary heapCapacitySummary) {
             this.heapCapacitySummary = heapCapacitySummary;
+        }
+
+        public void setNMethodSummary(ZGCNMethodSummary nMethodSummary) {
+            this.nMethodSummary = nMethodSummary;
         }
     }
 

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/ZGCPatterns.java
@@ -47,6 +47,22 @@ public interface ZGCPatterns extends UnifiedPatterns {
     //[3.596s][info ][gc,reloc       ] GC(3) Relocation: Successful, 6M relocated
     GCParseRule RELOCATION_SUMMARY = new GCParseRule("Relocation Summary",OPT_GEN + "Relocation: Successful, (\\d+)M relocated");
 
+    //[2025-03-07T17:46:45.563-0800][info][gc,reloc    ] GC(380) Y:                        Candidates     Selected     In-Place         Size        Empty    Relocated
+    //[2025-03-07T17:46:45.563-0800][info][gc,reloc    ] GC(380) Y: Small Pages:                53993        26715            0      107986M       53924M         180M
+    //[2025-03-07T17:46:45.563-0800][info][gc,reloc    ] GC(380) Y: Medium Pages:                   2            0            0          64M          32M           0M
+    //[2025-03-07T17:46:45.563-0800][info][gc,reloc    ] GC(380) Y: Large Pages:                    0            0            0           0M           0M           0M
+    GCParseRule PAGES_GEN = new GCParseRule("Page Summary",OPT_GEN + "(Small|Medium|Large) Pages:\\s+" + INT + "\\s+" + INT + "\\s+" + INT + "\\s+" + INT + UNITS + "\\s+" + INT + UNITS + "\\s+" + INT + UNITS);
+
+    //[2025-03-07T17:46:50.397-0800][info][gc,reloc    ] GC(380) O: Forwarding Usage: 125M
+    GCParseRule FORWARDING_USAGE_GEN = new GCParseRule("Forwarding Usage",OPT_GEN + "Forwarding Usage: " + INT + UNITS);
+
+    // [2025-03-07T17:49:56.358-0800][info][gc,reloc    ] GC(389) y:                    Live             Garbage             Small              Medium             Large
+    //[2025-03-07T17:49:56.358-0800][info][gc,reloc    ] GC(389) y: Eden             234M (0%)       156765M (79%)      78484 / 36719          1 / 0              0 / 0
+    //[2025-03-07T17:49:56.358-0800][info][gc,reloc    ] GC(389) y: Survivor 1        52M (0%)          649M (0%)         335 / 275            1 / 1              0 / 0
+    //[2025-03-07T17:49:56.358-0800][info][gc,reloc    ] GC(389) y: Survivor 2        40M (0%)          255M (0%)         148 / 91             0 / 0              0 / 0
+    //[2025-03-07T17:49:56.359-0800][info][gc,reloc    ] GC(389) y: Survivor 3        38M (0%)           65M (0%)          52 / 20             0 / 0              0 / 0
+    GCParseRule AGE_TABLE_GEN = new GCParseRule("Age Table",OPT_GEN + "(Eden|Survivor \\d+)\\s+" + MEMORY_PERCENT + "\\s+" + MEMORY_PERCENT + "\\s+" + INT + " \\/ " + INT + "\\s+" + INT + " \\/ " + INT + "\\s+" + INT + " \\/ " + INT );
+
     //[3.596s][info ][gc,nmethod     ] GC(3) NMethods: 1163 registered, 0 unregistered
     GCParseRule NMETHODS = new GCParseRule("NMethods",OPT_GEN + " NMethods: " + GenericTokens.INT + " registered, " + GenericTokens.INT + " unregistered");
 

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/GenerationalZGCParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/GenerationalZGCParserTest.java
@@ -10,6 +10,7 @@ import com.microsoft.gctoolkit.event.zgc.ZGCAllocatedSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCCompactedSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCCycle;
 import com.microsoft.gctoolkit.event.zgc.ZGCGarbageSummary;
+import com.microsoft.gctoolkit.event.zgc.ZGCHeapCapacitySummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCLiveSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCMemoryPoolSummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCMemorySummary;
@@ -163,6 +164,8 @@ public class GenerationalZGCParserTest extends ParserTest {
             assertEquals(toInt(13.129d, 1000), toInt(young.getConcurrentRelocateDuration(), 1000));
 
             //Memory
+            assertTrue(checkZGCHeapSummary(young.getHeapCapacitySummary(), 36864, 36864, 36864));
+
             assertTrue(checkZGCMemoryPoolSummary(young.getMarkStart(), 36864, 36568, 296));
             assertTrue(checkZGCMemoryPoolSummary(young.getMarkEnd(), 36864, 36556, 308));
             assertTrue(checkZGCMemoryPoolSummary(young.getRelocateStart(),36864, 36624, 240));
@@ -223,6 +226,8 @@ public class GenerationalZGCParserTest extends ParserTest {
             assertTrue(checkReferenceSummary(old.getPhantomRefSummary(), 497, 0, 0));
 
             //Memory
+            assertTrue(checkZGCHeapSummary(old.getHeapCapacitySummary(), 36864, 36864, 36864));
+
             assertTrue(checkZGCMemoryPoolSummary(old.getMarkStart(), 36864, 36568, 296));
             assertTrue(checkZGCMemoryPoolSummary(old.getMarkEnd(), 36864, 36788, 76 ));
             assertTrue(checkZGCMemoryPoolSummary(old.getRelocateStart(),36864, 36784, 80));
@@ -343,6 +348,8 @@ public class GenerationalZGCParserTest extends ParserTest {
             assertEquals(toInt(198.752d, 1000), toInt(young.getConcurrentRelocateDuration(), 1000));
 
             //Memory
+            assertTrue(checkZGCHeapSummary(young.getHeapCapacitySummary(), 36864, 36864, 36864));
+
             assertTrue(checkZGCMemoryPoolSummary(young.getMarkStart(), 36864, 22144, 14720));
             assertTrue(checkZGCMemoryPoolSummary(young.getMarkEnd(), 36864, 21376, 15488));
             assertTrue(checkZGCMemoryPoolSummary(young.getRelocateStart(),36864, 23912, 12952));
@@ -392,6 +399,11 @@ public class GenerationalZGCParserTest extends ParserTest {
     private boolean checkZGCMetaSpaceSummary(ZGCMetaspaceSummary summary, long usedMb, long committedMb, long reservedMb) {
         return summary.getUsed() ==(usedMb * 1024) && summary.getCommitted() == (committedMb * 1024) && summary.getReserved() == (reservedMb * 1024);
     }
+
+    private boolean checkZGCHeapSummary(ZGCHeapCapacitySummary summary, long minCapacityMb, long maxCapacityMb , long softMaxCapacityMb) {
+        return summary.getMinCapacity() == (minCapacityMb * 1024) && summary.getMaxCapacity() == (maxCapacityMb * 1024) && summary.getSoftMaxCapacity() == (softMaxCapacityMb * 1024);
+    }
+
 
     private boolean checkZGCMemoryPoolSummary(ZGCMemoryPoolSummary summary, long capacityMb, long freeMb , long usedMb) {
         return summary.getCapacity() == (capacityMb * 1024) && summary.getFree() == (freeMb * 1024) && summary.getUsed() == (usedMb * 1024);

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/GenerationalZGCParserTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/GenerationalZGCParserTest.java
@@ -60,6 +60,7 @@ public class GenerationalZGCParserTest extends ParserTest {
                 "[2025-02-11T13:06:19.551-0800][info][gc,mmu      ] GC(1) Y: MMU: 2ms/98.9%, 5ms/99.5%, 10ms/99.8%, 20ms/99.8%, 50ms/99.9%, 100ms/99.9%",
                 "[2025-02-11T13:06:19.551-0800][info][gc,marking  ] GC(1) Y: Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s) ",
                 "[2025-02-11T13:06:19.551-0800][info][gc,marking  ] GC(1) Y: Mark Stack Usage: 32M",
+                "[2025-02-11T13:06:19.551-0800][info][gc,nmethod  ] GC(1) Y: NMethods: 2335 registered, 0 unregistered",
                 "[2025-02-11T13:06:19.551-0800][info][gc,metaspace] GC(1) Y: Metaspace: 36M used, 37M committed, 1088M reserved",
                 "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y:                        Candidates     Selected     In-Place         Size        Empty    Relocated ",
                 "[2025-02-11T13:06:19.551-0800][info][gc,reloc    ] GC(1) Y: Small Pages:                  112           85            0         224M          36M           6M ",
@@ -102,6 +103,7 @@ public class GenerationalZGCParserTest extends ParserTest {
                 "[2025-02-11T13:06:19.580-0800][info][gc,mmu      ] GC(1) O: MMU: 2ms/98.9%, 5ms/99.5%, 10ms/99.8%, 20ms/99.8%, 50ms/99.9%, 100ms/99.9%",
                 "[2025-02-11T13:06:19.580-0800][info][gc,marking  ] GC(1) O: Mark: 1 stripe(s), 1 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s) ",
                 "[2025-02-11T13:06:19.580-0800][info][gc,marking  ] GC(1) O: Mark Stack Usage: 0M",
+                "[2025-02-11T13:06:19.580-0800][info][gc,nmethod  ] GC(1) O: NMethods: 5978 registered, 1490 unregistered",
                 "[2025-02-11T13:06:19.580-0800][info][gc,metaspace] GC(1) O: Metaspace: 36M used, 37M committed, 1088M reserved",
                 "[2025-02-11T13:06:19.580-0800][info][gc,ref      ] GC(1) O:                       Encountered   Discovered     Enqueued ",
                 "[2025-02-11T13:06:19.580-0800][info][gc,ref      ] GC(1) O: Soft References:             4193            0            0 ",
@@ -182,6 +184,9 @@ public class GenerationalZGCParserTest extends ParserTest {
             assertTrue(checkPromotedSummary(young.getPromotedSummary(), 0, 0));
             assertTrue(checkCompactedSummary(young.getCompactedSummary(), 10));
 
+            assertEquals(2335, young.getNMethodSummary().getRegistered());
+            assertEquals(0, young.getNMethodSummary().getUnregistered());
+
             assertEquals(7.61, young.getLoadAverageAt(1));
             assertEquals(12.83, young.getLoadAverageAt(5));
             assertEquals(13.76, young.getLoadAverageAt(15));
@@ -244,6 +249,9 @@ public class GenerationalZGCParserTest extends ParserTest {
             assertNull(old.getPromotedSummary());
             assertTrue(checkCompactedSummary(old.getCompactedSummary(), 0));
 
+            assertEquals(5978, old.getNMethodSummary().getRegistered());
+            assertEquals(1490, old.getNMethodSummary().getUnregistered());
+
             assertEquals(7.61, old.getLoadAverageAt(1));
             assertEquals(12.83, old.getLoadAverageAt(5));
             assertEquals(13.76, old.getLoadAverageAt(15));
@@ -280,6 +288,7 @@ public class GenerationalZGCParserTest extends ParserTest {
                 "[2025-02-11T13:07:13.255-0800][info][gc,mmu      ] GC(7) y: MMU: 2ms/97.7%, 5ms/99.1%, 10ms/99.5%, 20ms/99.8%, 50ms/99.9%, 100ms/99.9%",
                 "[2025-02-11T13:07:13.255-0800][info][gc,marking  ] GC(7) y: Mark: 1 stripe(s), 2 proactive flush(es), 1 terminate flush(es), 0 completion(s), 0 continuation(s) ",
                 "[2025-02-11T13:07:13.255-0800][info][gc,marking  ] GC(7) y: Mark Stack Usage: 32M",
+                "[2025-02-11T13:07:13.255-0800][info][gc,nmethod  ] GC(7) y: NMethods: 2335 registered, 0 unregistered",
                 "[2025-02-11T13:07:13.255-0800][info][gc,metaspace] GC(7) y: Metaspace: 100M used, 101M committed, 1152M reserved",
                 "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y:                        Candidates     Selected     In-Place         Size        Empty    Relocated ",
                 "[2025-02-11T13:07:13.255-0800][info][gc,reloc    ] GC(7) y: Small Pages:                 7066         5720            0       14132M        2554M          74M ",
@@ -365,6 +374,9 @@ public class GenerationalZGCParserTest extends ParserTest {
             assertTrue(checkReclaimSummary(young.getReclaimSummary(), 2554, 14009));
             assertTrue(checkPromotedSummary(young.getPromotedSummary(), 0, 0));
             assertTrue(checkCompactedSummary(young.getCompactedSummary(), 104));
+
+            assertEquals(2335, young.getNMethodSummary().getRegistered());
+            assertEquals(0, young.getNMethodSummary().getUnregistered());
 
             assertEquals(17.42, young.getLoadAverageAt(1));
             assertEquals(14.37, young.getLoadAverageAt(5));


### PR DESCRIPTION
This PR includes 3 commits to add support for more of the missing **info** level logging output for Generational ZGC cycles. It includes the following:

1. Support for heap capacity measurements, Min, Max, Soft Max
2. Support for nMethod Tracking, registered and unregistered
3. Support for Relocation information including Page Summary for Small, Medium and Large pages as well as an Age Table with a summary broken down by generation, Eden, Survivor 1-14.  
