### PR TITLE
Fix for Gctoolkit #372 - YoungDetails event not published for GC log collected with -Xlog:gc (no *)

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/jvm/Diary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/jvm/Diary.java
@@ -378,6 +378,10 @@ public class Diary {
         return isApplicationStoppedTimeKnown() && isApplicationRunningTime();
     }
 
+    public boolean isPrintCPUTimes() {
+    	return isStateKnown(SupportedFlags.PRINT_CPU_TIMES);
+    }
+    
     public void setTimeOfFirstEvent(DateTimeStamp startTime) {
         if ( this.timeOfFirstEvent == null)
             this.timeOfFirstEvent = startTime;

--- a/api/src/main/java/com/microsoft/gctoolkit/jvm/SupportedFlags.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/jvm/SupportedFlags.java
@@ -35,6 +35,8 @@ public enum SupportedFlags {
     MAX_TENURING_THRESHOLD_VIOLATION,           // 24
     TLAB_DATA,                                  // 25
     PRINT_PROMOTION_FAILURE,                    // 26
-    PRINT_FLS_STATISTICS                        // 27
+    PRINT_FLS_STATISTICS,                       // 27
+    
+    PRINT_CPU_TIMES								// 28
 
 }

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/UnifiedDiarizer.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/UnifiedDiarizer.java
@@ -117,6 +117,9 @@ public class UnifiedDiarizer implements Diarizer {
                 diary.setTrue(GC_DETAILS);
             else if ( decorators.tagsContain("gc,ergo"))
                 diary.setTrue(ADAPTIVE_SIZING);
+            else if (decorators.tagsContain("gc,cpu"))
+            	diary.setTrue(PRINT_CPU_TIMES);
+            
             if (decorators.tagsContain("safepoint"))
                 diary.setTrue(APPLICATION_STOPPED_TIME, APPLICATION_CONCURRENT_TIME);
 

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/G1GCUnifiedParserRulesTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/G1GCUnifiedParserRulesTest.java
@@ -215,7 +215,8 @@ public class G1GCUnifiedParserRulesTest implements UnifiedG1GCPatterns {
                     "[6.641s][info][gc           ] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 23M->6M(64M) 6.302ms",
                     "[7.965s][info][gc            ] GC(415) Pause Young (Concurrent Start) (G1 Evacuation Pause) 49M->30M(64M) 1.965ms",
                     "[7.981s][info][gc            ] GC(419) Pause Young (Prepare Mixed) (G1 Evacuation Pause) 43M->16M(64M) 1.734ms",
-                    "[7.984s][info][gc            ] GC(420) Pause Young (Mixed) (G1 Evacuation Pause) 26M->11M(64M) 1.453ms"
+                    "[7.984s][info][gc            ] GC(420) Pause Young (Mixed) (G1 Evacuation Pause) 26M->11M(64M) 1.453ms",
+                    "[19.869s][info][gc] GC(8) Pause Young (Normal) (G1 Evacuation Pause) 170M->42M(1024M) 8.502ms"
             },
             {   //  9
                     "[2018-03-09T11:14:05.002-0100][12.277s][info ][gc,cpu       ] GC(0) User=0.04s Sys=0.01s Real=0.01s"

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/diary/G1DiarizerTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/diary/G1DiarizerTest.java
@@ -206,9 +206,9 @@ public class G1DiarizerTest extends LogDiaryTest {
     };
 
     private static final boolean[][] unifiedDiary = {
-            //   0      1      2      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17     18,    19,    20,    21,    22,    23,    24,    25,    26,    27
-            { true,  true, false, false, false, false, false, false, false,  true, false, false,  true,  true,  true, false, false, false, false, false,  true, false, false,  true, false, false, false, false},
-            { true,  true, false, false, false, false, false, false, false,  true, false, false,  true,  true,  true, false, false, false, false, false,  true, false, false,  true, false, false, false, false}
+            //   0      1      2      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17     18,    19,    20,    21,    22,    23,    24,    25,    26,    27,   28
+            { true,  true, false, false, false, false, false, false, false,  true, false, false,  true,  true,  true, false, false, false, false, false,  true, false, false,  true, false, false, false, false, true},
+            { true,  true, false, false, false, false, false, false, false,  true, false, false,  true,  true,  true, false, false, false, false, false,  true, false, false,  true, false, false, false, false, true}
     };
 
     private static final int[][] unifiedUnknown = {
@@ -217,8 +217,8 @@ public class G1DiarizerTest extends LogDiaryTest {
     };
 
     private static final int[][] unifiedKnown = {
-            {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27},
-            {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27}
+            {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28},
+            {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28}
     };
 
 }

--- a/parser/src/test/java/com/microsoft/gctoolkit/parser/diary/LogDiaryTest.java
+++ b/parser/src/test/java/com/microsoft/gctoolkit/parser/diary/LogDiaryTest.java
@@ -13,7 +13,6 @@ import com.microsoft.gctoolkit.parser.jvm.UnifiedDiarizer;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -288,6 +287,9 @@ abstract class LogDiaryTest {
                     case 27:
                         assertTrue(name + ":PRINT_FLS_STATISTICS should be known", diary.isPrintFLSStatisticsKnown());
                         break;
+                    case 28:
+                    	assertTrue(name + ":PRINT_CPU_TIMES should be known", diary.isPrintCPUTimes());
+                    	break;
                     default:
                         fail("unknown unknown");
                 }


### PR DESCRIPTION
**Approach:**

Both files that are generated using -Xlog:gc and -Xlog:gc* use the same general format for the log line of interest:
-Xlog:gc: `[6.837s][info][gc] GC(3) Pause Young (Normal) (G1 Evacuation Pause) 79M->27M(1024M) 2.929ms`
-Xlog:gc*: `[1.361s][info ][gc          ] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 18874M->9037M(81920M) 23.698ms`

The main difference is that for -Xlog:gc, this is the only line that is printed for an event, whereas -Xlog:gc* prints a CPU time line right afterward, which GCToolkit currently uses as a publish trigger:
`[1.361s][info ][gc,cpu      ] GC(0) User=0.95s Sys=0.09s Real=0.02s`

To address this issue, I've added a Diarizer flag PRINT_CPU_TIMES that is populated when extracting decorators.  If this flag is unset/unsure, the UnifiedG1GCParser.youngDetails() method will populate remaining fields (GC Type - Young, GC Cause extracted from trace 4 (offset -2), StartTime as reported by getClock()) and attempt to publish the event.  I have left in a null check on GCType in the publish condition as a failsafe, but in theory it could be removed.

I think this should be reasonably solid, is a relatively minor change, and it will keep events being published in order.

**Test Updates**
Not much done here, other than adding a couple of updates to existing test cases.  I can provide a sample file, and can update some additional suites, though I wanted to confirm how I can go about doing that.  Is it just a matter of a PR to gctoolkit-testdata with the new file first?