### PR TITLE
update deps 22 apr 2025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,36 +45,36 @@
 
     <properties>
         <revision>3.0.3-SNAPSHOT</revision>
-        <checkstyle.version>10.21.1</checkstyle.version>
-        <jreleaser.plugin.version>1.16.0</jreleaser.plugin.version>
-        <junit5.version>5.11.4</junit5.version>
+        <checkstyle.version>10.23.0</checkstyle.version>
+        <jreleaser.plugin.version>1.17.0</jreleaser.plugin.version>
+        <junit5.version>5.12.2</junit5.version>
         <maven.antrun-plugin.version>3.1.0</maven.antrun-plugin.version>
         <maven.changes-plugin.version>3.0.0-M2</maven.changes-plugin.version>
         <maven.checkstyle-plugin.version>3.6.0</maven.checkstyle-plugin.version>
-        <maven.clean-plugin.version>3.4.0</maven.clean-plugin.version>
-        <maven.compiler-plugin.version>3.13.0</maven.compiler-plugin.version>
+        <maven.clean-plugin.version>3.4.1</maven.clean-plugin.version>
+        <maven.compiler-plugin.version>3.14.0</maven.compiler-plugin.version>
         <maven.compiler.release>11</maven.compiler.release>
         <maven.dependency-plugin.version>3.8.1</maven.dependency-plugin.version>
-        <maven.deploy-plugin.version>3.1.3</maven.deploy-plugin.version>
+        <maven.deploy-plugin.version>3.1.4</maven.deploy-plugin.version>
         <maven.directory-maven-plugin.version>1.0</maven.directory-maven-plugin.version>
         <maven.enforcer-plugin.version>3.5.0</maven.enforcer-plugin.version>
         <maven.exec-plugin.version>3.5.0</maven.exec-plugin.version>
-        <maven.install-plugin.version>3.1.3</maven.install-plugin.version>
-        <maven.jacoco-plugin.version>0.8.12</maven.jacoco-plugin.version>
+        <maven.install-plugin.version>3.1.4</maven.install-plugin.version>
+        <maven.jacoco-plugin.version>0.8.13</maven.jacoco-plugin.version>
         <maven.jar-plugin.version>3.4.2</maven.jar-plugin.version>
         <maven.javadoc-plugin.version>3.11.2</maven.javadoc-plugin.version>
         <maven.jxr-plugin.version>3.6.0</maven.jxr-plugin.version>
         <maven.license-plugin.version>2.5.0</maven.license-plugin.version>
         <!-- TODO Upgrade to 3.26.0+ once we move to PMD 7.8.0+ -->
         <maven.pmd-plugin.version>3.21.2</maven.pmd-plugin.version>
-        <maven.project-info-reports-plugin.version>3.8.0</maven.project-info-reports-plugin.version>
+        <maven.project-info-reports-plugin.version>3.9.0</maven.project-info-reports-plugin.version>
         <maven.rat-plugin.version>0.16.1</maven.rat-plugin.version>
         <maven.release-plugin.version>3.1.1</maven.release-plugin.version>
         <maven.resources-plugin.version>3.3.1</maven.resources-plugin.version>
         <maven.site-plugin.version>4.0.0-M16</maven.site-plugin.version>
         <maven.source-plugin.version>3.3.1</maven.source-plugin.version>
-        <maven.spotbugs-plugin.version>4.8.6.6</maven.spotbugs-plugin.version>
-        <maven.surefire-plugin.version>3.5.2</maven.surefire-plugin.version>
+        <maven.spotbugs-plugin.version>4.9.3.0</maven.spotbugs-plugin.version>
+        <maven.surefire-plugin.version>3.5.3</maven.surefire-plugin.version>
         <maven.version>3.9.9</maven.version>
         <maven.versions-plugin.version>2.18.0</maven.versions-plugin.version>
         <mutability.detector.version>0.9.1</mutability.detector.version>
@@ -83,7 +83,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.github.repository>microsoft/gctoolkit</project.github.repository>
         <repository.url>git@github.com:${project.github.repository}.git</repository.url>
-        <spotbugs.version>4.8.6</spotbugs.version>
+        <spotbugs.version>4.9.3</spotbugs.version>
     </properties>
 
     <modules>
@@ -395,7 +395,7 @@
                 <reportSets>
                     <reportSet>
                         <reports>
-                            <report>changes-report</report>
+                            <report>changes</report>
                             <!-- TODO -->
                             <!-- <report>github-report</report> -->
                         </reports>
@@ -463,7 +463,7 @@
             <plugin>
                 <groupId>org.hjug.refactorfirst.plugin</groupId>
                 <artifactId>refactor-first-maven-plugin</artifactId>
-                <version>0.6.2</version>
+                <version>0.7.1</version>
                 <!-- optional -->
                 <configuration>
                     <showDetails>true</showDetails>

--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
- **Update dependencies, all tests pass (#410)**
- **Bump actions/setup-java from 4.6.0 to 4.7.0 (#411)**
- **[maven-release-plugin] prepare release gctoolkit-3.2.0**
- **[maven-release-plugin] prepare for next development iteration**
- **[maven-release-plugin] prepare release gctoolkit-3.3.0**
- **[maven-release-plugin] prepare for next development iteration**
- **[maven-release-plugin] prepare release gctoolkit-3.4.0**
- **[maven-release-plugin] prepare for next development iteration**
- **Bump actions/cache from 4.2.0 to 4.2.1 (#413)**
- **bump vertx-core version (#415)**
- **ZGC Generational Support (#414)**
- **fix jreleaser issue (#416)**
- **[maven-release-plugin] prepare release gctoolkit-3.5.0**
- **[maven-release-plugin] prepare for next development iteration**
- **Bump actions/cache from 4.2.1 to 4.2.2 (#418)**
- **Add missing GC causes from gcCause.cpp (#420)**
- **ZGC Fixes from #414 (#417)**
- **Change ZGC start tag (#419)**
- **Move stdout direct logging under debug mode (#422)**
- **Ensure FullZGCCycle has all delegate methods (#423)**
- **Bump actions/cache from 4.2.2 to 4.2.3 (#425)**
- **Bump actions/setup-java from 4.7.0 to 4.7.1 (#428)**
- **[ZGC] Add support for heap capacity, nMethod and relocation summary (#426)**
- **Fix for Gctoolkit #372 - YoungDetails event not published for GC log collected with -Xlog:gc (no *) (#430)**
- **Updated dependencies - all tests pass**
