### PR TITLE
Heap region size for G1GC is no longer parsed after JDK-8244817

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/UnifiedG1GCPatterns.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/unified/UnifiedG1GCPatterns.java
@@ -54,7 +54,7 @@ public interface UnifiedG1GCPatterns extends UnifiedPatterns {
     //[90.452s][info ][gc           ] GC(1459) Pause Young (G1 Evacuation Pause) 574M->4M(953M) 2.065ms
     GCParseRule YOUNG_DETAILS = new GCParseRule("YOUNG_DETAILS", "Pause " + YOUNG_COLLECTION_TYPES + " (\\(" + YOUNG_COLLECTION_SUB_TYPE + "\\) )?" + GC_CAUSE + BEFORE_AFTER_CONFIGURED_PAUSE);
 
-    GCParseRule HEAP_REGION_SIZE = new GCParseRule("HEAP_REGION_SIZE", "Heap region size: " + MEMORY_SIZE);
+    GCParseRule HEAP_REGION_SIZE = new GCParseRule("HEAP_REGION_SIZE", "Heap [Rr]egion [Ss]ize: " + MEMORY_SIZE);
 
     GCParseRule HEAP_SIZE = new GCParseRule("HEAP_SIZE", "Minimum heap " + COUNTER + "  Initial heap " + COUNTER + "  Maximum heap " + COUNTER);
 


### PR DESCRIPTION
Starting with [JDK-8244817](https://bugs.openjdk.org/browse/JDK-8244817), the heap region size can no longer be detected by the pattern `Heap region size` but by `Heap Region Size` (note the capitalized `Region` and `Size`) in G1GC log files.

As a result of not being able to retrieve heap region size, GCToolkit is not able to report the occupancy of the various  G1 memory pool types (eden, survival, old).