### PR TITLE
Added missing memory pools for heap regions (old, humongous) and metaspace (class space) in unified G1GC logs.

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/event/g1gc/G1GCPauseEvent.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/g1gc/G1GCPauseEvent.java
@@ -18,8 +18,11 @@ public abstract class G1GCPauseEvent extends G1GCEvent {
 
     private MemoryPoolSummary eden;
     private SurvivorMemoryPoolSummary survivor;
+    private MemoryPoolSummary old;
+    private MemoryPoolSummary humongous;
     private MemoryPoolSummary heap;
     private MemoryPoolSummary permOrMetaspace;
+    private MemoryPoolSummary classSpace;
     private ReferenceGCSummary referenceGCSummary = null;
 
     private RegionSummary edenRegion;
@@ -45,8 +48,25 @@ public abstract class G1GCPauseEvent extends G1GCEvent {
         this.addMemorySummary(null, null, heap);
     }
 
+    public void addMemorySummary(MemoryPoolSummary eden,
+                                 SurvivorMemoryPoolSummary survivor,
+                                 MemoryPoolSummary old,
+                                 MemoryPoolSummary humongous,
+                                 MemoryPoolSummary heap) {
+        this.eden = eden;
+        this.survivor = survivor;
+        this.old = old;
+        this.humongous = humongous;
+        this.heap = heap;
+    }
+
     public void addPermOrMetaSpaceRecord(MemoryPoolSummary permOrMetaspaceRecord) {
-        permOrMetaspace = permOrMetaspaceRecord;
+       addPermOrMetaSpaceRecord(permOrMetaspaceRecord, null);
+    }
+
+    public void addPermOrMetaSpaceRecord(MemoryPoolSummary permOrMetaspaceRecord, MemoryPoolSummary classSpace) {
+        this.permOrMetaspace = permOrMetaspaceRecord;
+        this.classSpace =  classSpace;
     }
 
     public void addCPUSummary(CPUSummary summary) {
@@ -95,6 +115,18 @@ public abstract class G1GCPauseEvent extends G1GCEvent {
 
     public MemoryPoolSummary getPermOrMetaspace() {
         return this.permOrMetaspace;
+    }
+
+    public MemoryPoolSummary getHumongous() {
+        return humongous;
+    }
+
+    public MemoryPoolSummary getOld() {
+        return old;
+    }
+
+    public MemoryPoolSummary getClassSpace() {
+        return classSpace;
     }
 
     public MemoryPoolSummary getTenured() {

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/G1GCForwardReference.java
@@ -542,15 +542,10 @@ class G1GCForwardReference extends ForwardReference {
         MemoryPoolSummary young = getMemoryPoolSummary(YOUNG_OCCUPANCY_BEFORE_COLLECTION);
         MemoryPoolSummary eden = getMemoryPoolSummary(EDEN_OCCUPANCY_BEFORE_COLLECTION);
         SurvivorMemoryPoolSummary survivor = getSurvivorMemoryPoolSummary();
-        MemoryPoolSummary tenured = getMemoryPoolSummary(OLD_OCCUPANCY_BEFORE_COLLECTION);
+        MemoryPoolSummary old = getMemoryPoolSummary(OLD_OCCUPANCY_BEFORE_COLLECTION);
         MemoryPoolSummary humongous = getMemoryPoolSummary(HUMONGOUS_OCCUPANCY_BEFORE_COLLECTION);
         collection.addHeapRegionSize(heapRegionSize);
-        if (heap != null && eden != null && survivor != null) {
-            collection.addMemorySummary(eden, survivor, heap);
-        } else if (eden == null && survivor == null && heap != null) {
-            collection.addMemorySummary(heap);
-        } //else
-        //need to consider other possible combinations.
+        collection.addMemorySummary(eden, survivor, old, humongous, heap);
     }
 
     /*
@@ -564,7 +559,9 @@ class G1GCForwardReference extends ForwardReference {
     private static final int METASPACE_RESERVED_AFTER_COLLECTION = 31;
      */
     private void fillInMetaspaceStats(G1GCPauseEvent collection) {
-        collection.addPermOrMetaSpaceRecord(getMemoryPoolSummary(METASPACE_OCCUPANCY_BEFORE_COLLECTION));
+        collection.addPermOrMetaSpaceRecord(
+                getMemoryPoolSummary(METASPACE_OCCUPANCY_BEFORE_COLLECTION),
+                getMemoryPoolSummary(CLASSSPACE_OCCUPANCY_BEFORE_COLLECTION));
     }
 
 

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedG1GCParser.java
@@ -549,7 +549,7 @@ public class UnifiedG1GCParser extends UnifiedGCLogParser implements UnifiedG1GC
         forwardReference.setMetaspaceSizeAfterCollection(metaspace.getSizeAfterCollection());
         MemoryPoolSummary classSpace = trace.getEnlargedMetaSpaceRecord(17);
         forwardReference.setClassspaceOccupancyBeforeCollection(classSpace.getOccupancyBeforeCollection());
-        forwardReference.setClassspaceCommittedAfterCollection(classSpace.getOccupancyAfterCollection());
+        forwardReference.setClassspaceOccupancyAfterCollection(classSpace.getOccupancyAfterCollection());
         forwardReference.setClassspaceSizeAfterCollection(classSpace.getSizeAfterCollection());
     }
 


### PR DESCRIPTION
This PR exposes the following `MemoryPoolSummary` instances in `G1GCPauseEvent`:
* `old`
* `humongous`
* `classSpace`

By and large,  the actual parsing was already done, I mostly just surfaced it in the event.