### PR TITLE
Make UnifiedGCLogParser public

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedGCLogParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/UnifiedGCLogParser.java
@@ -41,6 +41,7 @@ public abstract class UnifiedGCLogParser extends GCLogParser {
 
     public UnifiedGCLogParser() {}
 
+    @Override
     protected void advanceClock(String record) {
         try {
             DateTimeStamp now = new Decorators(record).getDateTimeStamp();


### PR DESCRIPTION
Make it possible to extend it in third party packages.

We have an implementation of this, and it currently extends from `UnifiedGenerationalParser` for no other reason that it is public.

For more information, there is nothing very exciting about our custom implementation, it just collects all the info printed on start:
```
[2025-11-10T02:00:05.581+0100][0.005s] Parallel Workers: 2
[2025-11-10T02:00:05.581+0100][0.005s] Compressed Oops: Enabled (32-bit)
[2025-11-10T02:00:05.581+0100][0.005s] Version: 21.0.8+9-LTS (release)
[2025-11-10T02:00:05.581+0100][0.005s] Memory: 2048M
[2025-11-10T02:00:05.589+0100][0.012s] Compressed class space mapped at: 0x00007fb2a6000000-0x00007fb2ba000000, reserved size: 335544320
[2025-11-10T02:00:05.581+0100][0.005s] CPUs: 8 total, 1 available
[2025-11-10T02:00:05.580+0100][0.003s] CardTable entry size: 512
...
```