### PR TITLE
Faster Decorators parsing

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/Decorators.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/Decorators.java
@@ -59,7 +59,7 @@ public class Decorators {
 
     private static final Logger LOGGER = Logger.getLogger(Decorators.class.getName());
 
-    // cheap optim, assume that most logs are at info or debug level and thus put those at the head of the list
+    // Predictive optimization, assume that most logs are at info or debug level and thus put those at the head of the list
     private static final List<String> LEVELS = List.of("info", "debug", "error", "warning", "trace", "develop");
     // not the same as UnifiedLoggingTokens.TAGS as there is no literal brackets here
     private static final Pattern TAGS = Pattern.compile("[a-z0-9,. ]+");

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/Decorators.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/Decorators.java
@@ -61,7 +61,7 @@ public class Decorators {
 
     // Predictive optimization, assume that most logs are at info or debug level and thus put those at the head of the list
     private static final List<String> LEVELS = List.of("info", "debug", "error", "warning", "trace", "develop");
-    // not the same as UnifiedLoggingTokens.TAGS as there is no literal brackets here
+    // This is *not* the same as UnifiedLoggingTokens.TAGS as there are no literal brackets here
     private static final Pattern TAGS = Pattern.compile("[a-z0-9,. ]+");
 
     // This is to help differentiate between JVM running time and wall clock time.

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/Decorators.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/jvm/Decorators.java
@@ -91,7 +91,7 @@ public class Decorators {
         if (line.charAt(0) != '[') {
             return;
         }
-        // don't assign fields until we are done parsing, to avoid inconsistent state
+        // To avoid inconsistent state, don't assign fields until we are done parsing.
         int numberOfDecorators = 0;
         for (int i = 0; i < line.length() - 1; i++) {
             if (line.charAt(i) == ']') {


### PR DESCRIPTION
This is pretty hot in profiles.

I know it was already improved in https://github.com/microsoft/gctoolkit/pull/458, but we can get rid of the regex altogether.