### PR TITLE
Change to the linux-x64 test pool

### DIFF
--- a/.devops/gctoolkit-release.yml
+++ b/.devops/gctoolkit-release.yml
@@ -42,7 +42,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     pool:
-      name: JEG-test-pool
+      name: JEG-test-pool-x64
       os: linux
     sdl:
       sourceAnalysisPool:


### PR DESCRIPTION
We are in the process of updating our build agents, once that work is complete we will fix this properly.