### PR TITLE
docs: cross-link contributor guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ if you wish to contribute to GCToolKit we would kindly ask that you submit an is
 
 The build requires JDK 11 and uses the Maven wrapper (`mvnw`) to help ensure reproducible builds and so we don't force you to change your system Maven install. If you prefer to build with your local Maven installation, make sure the version matches the one in the project's [.mvn/wrapper/maven-wrapper.properties](https://github.com/microsoft/gctoolkit/blob/main/.mvn/wrapper/maven-wrapper.properties) file. You can also use JDK 17 or 21 by passing in `-Dmaven.compiler.release=<17|21>` as an extra property to any of the `./mvnw` commands below.
 
+For more detail about the project architecture and how GCToolKit components fit together, see the [Developer's Guide](DEVELOPERS_GUIDE.md).
+
 * `./mvnw clean` - remove build artifacts
 * `./mvnw compile` - compile the source code.
 

--- a/DEVELOPERS_GUIDE.md
+++ b/DEVELOPERS_GUIDE.md
@@ -8,6 +8,8 @@ GCToolkit is comprised of 3 Java modules, vertx, parser, and api. This document 
 Additionally, GCToolkit contains several components that perform the heavy lifting. These components include, a framework to interact with data sources, diary, data source bus, parsers, and event source bus and finally, a framework to support the aggregation of events.
 The purpose of this document is to provide a brief description of each of these components to aid in the further development of this toolkit.
 
+If you are preparing a contribution, start with [CONTRIBUTING.md](CONTRIBUTING.md) for issue, build, test, and pull request guidance.
+
 ![GCToolkit Design](images/gctoolkit_design.png)
 Fig 1. GCToolKit Component Map
 


### PR DESCRIPTION
Closes #200

## Summary
- link from `CONTRIBUTING.md` to the Developer's Guide for architecture context
- link from `DEVELOPERS_GUIDE.md` back to contributing guidance for issue, build, test, and PR details

## Verification
- `rg -n "Developer's Guide|CONTRIBUTING.md|DEVELOPERS_GUIDE.md" CONTRIBUTING.md DEVELOPERS_GUIDE.md README.md`
- `git diff --check`