### PR TITLE
Guard heap occupancy sample aggregation

### DIFF
--- a/sample/src/main/java/com/microsoft/gctoolkit/sample/aggregation/HeapOccupancyAfterCollection.java
+++ b/sample/src/main/java/com/microsoft/gctoolkit/sample/aggregation/HeapOccupancyAfterCollection.java
@@ -3,12 +3,16 @@ package com.microsoft.gctoolkit.sample.aggregation;
 import com.microsoft.gctoolkit.aggregator.Aggregates;
 import com.microsoft.gctoolkit.aggregator.Aggregator;
 import com.microsoft.gctoolkit.aggregator.EventSource;
+import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
+import com.microsoft.gctoolkit.event.MemoryPoolSummary;
 import com.microsoft.gctoolkit.event.g1gc.G1GCPauseEvent;
 import com.microsoft.gctoolkit.event.generational.GenerationalGCPauseEvent;
 import com.microsoft.gctoolkit.event.shenandoah.ShenandoahCycle;
 import com.microsoft.gctoolkit.event.zgc.ZGCFullCollection;
+import com.microsoft.gctoolkit.event.zgc.ZGCMemorySummary;
 import com.microsoft.gctoolkit.event.zgc.ZGCOldCollection;
 import com.microsoft.gctoolkit.event.zgc.ZGCYoungCollection;
+import com.microsoft.gctoolkit.time.DateTimeStamp;
 
 @Aggregates({EventSource.G1GC,EventSource.GENERATIONAL,EventSource.ZGC,EventSource.SHENANDOAH})
 public class HeapOccupancyAfterCollection extends Aggregator<HeapOccupancyAfterCollectionAggregation> {
@@ -24,28 +28,39 @@ public class HeapOccupancyAfterCollection extends Aggregator<HeapOccupancyAfterC
     }
 
     private void extractHeapOccupancy(ZGCYoungCollection event) {
-        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary().getOccupancyAfter());
+        addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary());
     }
 
     private void extractHeapOccupancy(ZGCOldCollection event) {
-        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary().getOccupancyAfter());
+        addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary());
     }
 
     private void extractHeapOccupancy(GenerationalGCPauseEvent event) {
-        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getHeap().getOccupancyAfterCollection());
+        addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getHeap());
     }
 
     private void extractHeapOccupancy(G1GCPauseEvent event) {
-        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getHeap().getOccupancyAfterCollection());
+        addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getHeap());
 
     }
 
     private void extractHeapOccupancy(ZGCFullCollection event) {
-        aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary().getOccupancyAfter());
+        addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getMemorySummary());
     }
 
     private void extractHeapOccupancy(ShenandoahCycle event) {
         //aggregation().addDataPoint(event.getGarbageCollectionType(), event.getDateTimeStamp(), event.getOccupancy());
     }
-}
 
+    private void addDataPoint(GarbageCollectionTypes gcType, DateTimeStamp timeStamp, MemoryPoolSummary heap) {
+        if (heap != null) {
+            aggregation().addDataPoint(gcType, timeStamp, heap.getOccupancyAfterCollection());
+        }
+    }
+
+    private void addDataPoint(GarbageCollectionTypes gcType, DateTimeStamp timeStamp, ZGCMemorySummary summary) {
+        if (summary != null) {
+            aggregation().addDataPoint(gcType, timeStamp, summary.getOccupancyAfter());
+        }
+    }
+}

--- a/sample/src/test/java/com/microsoft/gctoolkit/sample/aggregation/HeapOccupancyAfterCollectionTest.java
+++ b/sample/src/test/java/com/microsoft/gctoolkit/sample/aggregation/HeapOccupancyAfterCollectionTest.java
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.gctoolkit.sample.aggregation;
+
+import com.microsoft.gctoolkit.event.GCCause;
+import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
+import com.microsoft.gctoolkit.event.generational.DefNew;
+import com.microsoft.gctoolkit.event.zgc.ZGCYoungCollection;
+import com.microsoft.gctoolkit.time.DateTimeStamp;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HeapOccupancyAfterCollectionTest {
+
+    @Test
+    void ignoresGenerationalEventsWithoutHeapSummary() {
+        HeapOccupancyAfterCollectionSummary summary = new HeapOccupancyAfterCollectionSummary();
+        HeapOccupancyAfterCollection aggregator = new HeapOccupancyAfterCollection(summary);
+        DefNew event = new DefNew(new DateTimeStamp(1.0d), GCCause.ALLOCATION_FAILURE, 1.0d);
+
+        assertDoesNotThrow(() -> aggregator.receive(event));
+
+        assertTrue(summary.isEmpty());
+    }
+
+    @Test
+    void ignoresZgcEventsWithoutMemorySummary() {
+        HeapOccupancyAfterCollectionSummary summary = new HeapOccupancyAfterCollectionSummary();
+        HeapOccupancyAfterCollection aggregator = new HeapOccupancyAfterCollection(summary);
+        ZGCYoungCollection event = new ZGCYoungCollection(
+                new DateTimeStamp(1.0d),
+                GarbageCollectionTypes.ZGCMinorYoung,
+                GCCause.ALLOCATION_FAILURE,
+                1.0d
+        );
+
+        assertDoesNotThrow(() -> aggregator.receive(event));
+
+        assertTrue(summary.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- skip heap occupancy datapoints when GC events do not carry heap or ZGC memory summaries
- add sample aggregation regressions for generational and ZGC events with missing summaries

Closes #241.

## Testing
- `./mvnw -pl sample -am test -Dtest=HeapOccupancyAfterCollectionTest -Dsurefire.failIfNoSpecifiedTests=false`
- `git diff --check`