### PR TITLE
docs: add Javadoc for JVM diary API types

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/jvm/Diarizer.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/jvm/Diarizer.java
@@ -4,6 +4,10 @@ package com.microsoft.gctoolkit.jvm;
 
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
+/**
+ * Examines GC log input to infer the JVM logging format, collector configuration,
+ * command-line flags, and related diary information used by parsers.
+ */
 public interface Diarizer {
 
     int MAXIMUM_LINES_TO_EXAMINE = 10_000;

--- a/api/src/main/java/com/microsoft/gctoolkit/jvm/Diary.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/jvm/Diary.java
@@ -54,6 +54,13 @@ import static com.microsoft.gctoolkit.jvm.SupportedFlags.*;
     GENERATIONAL_ZGC                            // 29
  */
 
+/**
+ * Records discovered GC log feature states while a log is being diarized.
+ *
+ * <p>Each {@link SupportedFlags} entry is tracked as true, false, or unknown so
+ * parser selection and event-source discovery can defer decisions until enough
+ * log evidence has been observed.</p>
+ */
 public class Diary {
 
     private final TripleState[] states;

--- a/api/src/main/java/com/microsoft/gctoolkit/jvm/SupportedFlags.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/jvm/SupportedFlags.java
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 package com.microsoft.gctoolkit.jvm;
 
+/**
+ * Flags that describe JVM, collector, and log-detail features discovered while
+ * diarizing a GC log.
+ */
 public enum SupportedFlags {
     APPLICATION_STOPPED_TIME,                   //  0
     APPLICATION_CONCURRENT_TIME,                //  1


### PR DESCRIPTION
## Summary

Adds class-level Javadoc to three public JVM API types:

- `Diarizer`
- `Diary`
- `SupportedFlags`

This is a focused first pass for the public API documentation gap.

Refs #264.

## Validation

- Documentation-only change; no tests run.
