### PR TITLE
Cache duration Pattern in GenerationalHeapParser CMS remark path

### DIFF
--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/CMSPatterns.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/CMSPatterns.java
@@ -399,6 +399,7 @@ public interface CMSPatterns extends SharedPatterns {
 
     //8239.784: [Rescan (parallel) , 0.0444432 secs]8239.828: [weak refs processing8239.828: [SoftReference, 0 refs, 0.0000687 secs]8239.828: [WeakReference, 0 refs, 0.0000638 secs]8239.829: [FinalReference, 556 refs, 0.0008823 secs]8239.829: [PhantomReference, 0 refs, 0.0000657 secs]8239.830: [JNI Weak Reference, 0.0000995 secs], 0.0013332 secs]8239.830: [class unloading, 0.1926177 secs]8240.022: [scrub symbol table, 0.0376581 secs]8240.060: [scrub string table, 0.6722322 secs][1 CMS-remark: 6705100K(12523968K)] 6815820K(13520768K), 1.8735975 secs] [Times: user=7.84 sys=0.08, real=1.87 secs]
     GCParseRule SPLIT_REMARK_REFERENCE_BUG = new GCParseRule("SPLIT_REMARK_REFERENCE_BUG", "^" + DATE_TIMESTAMP + "\\[Rescan \\(parallel\\) , " + PAUSE_TIME + "\\]" + DATE_TIMESTAMP + "\\[weak refs processing" + DATE_TIMESTAMP);
+    GCParseRule SPLIT_REMARK_REFERENCE_BUG_DURATION = new GCParseRule("SPLIT_REMARK_REFERENCE_BUG_DURATION", "[^\\n]* " + PAUSE_TIME);
     GCParseRule SPLIT_REMARK_REFERENCE = new GCParseRule("SPLIT_REMARK_REFERENCE", "^" + RESCAN_BLOCK + WEAK_REF_BLOCK + CLASS_UNLOADING_BLOCK + SYMBOL_TABLE_SCRUB_BLOCK + STRING_TABLE_SCRUB_BLOCK + REMARK_BLOCK);
     GCParseRule FULL_SPLIT_BY_CONCURRENT_PHASE = new GCParseRule("FULL_SPLIT_BY_CONCURRENT_PHASE", "^" + DATE_TIMESTAMP + "\\[CMS" + CMS_PHASE_END);
 

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
@@ -65,7 +65,8 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
     private static final Logger LOGGER = Logger.getLogger(GenerationalHeapParser.class.getName());
 
     // Cached for the CMS remark/weak-reference split-bug path; avoid recompiling on every parse call.
-    private static final Pattern DURATION_GROUP_PATTERN = Pattern.compile(".* " + PAUSE_TIME);
+    // [^\n]* preserves last-match semantics of greedy .* without a ReDoS hotspot.
+    private static final Pattern DURATION_GROUP_PATTERN = Pattern.compile("[^\\n]* " + PAUSE_TIME);
 
     private ParNew parNewForwardReference;
     private GarbageCollectionTypes garbageCollectionTypeForwardReference;
@@ -629,9 +630,11 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
         gcCauseForwardReference = GCCause.PROMOTION_FAILED;
         ArrayList<Integer> blocks = new ArrayList<>();
         GCLogTrace block = PARNEW_PROMOTION_FAILURE_SIZE_BLOCK.parse(line);
-        do {
-            blocks.add(block.getIntegerGroup(1));
-        } while (block.hasNext());
+        if (block != null) {
+            do {
+                blocks.add(block.getIntegerGroup(1));
+            } while (block.hasNext());
+        }
         promotionFailureSizesForwardReference = new int[blocks.size()];
         for (int index = 0; index < blocks.size(); index++)
             promotionFailureSizesForwardReference[index] = blocks.get(index);
@@ -1820,7 +1823,8 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
     private void precleanTimedoutWithCards(GCLogTrace trace, String line) {
         abortPrecleanDueToTime = true;
         GCLogTrace concurrentPhase = new GCParseRule("X",CMS_PHASE_END).parse(line);
-        endOfConcurrentPhase(concurrentPhase, concurrentPhase.getDateTimeStamp(), 0);
+        if (concurrentPhase != null)
+            endOfConcurrentPhase(concurrentPhase, concurrentPhase.getDateTimeStamp(), 0);
     }
 
     private void shouldCollectConcurrent(GCLogTrace trace, String line) {
@@ -2069,6 +2073,10 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
 
     private void endConcurrentPrecleanWithReferenceProcessing(GCLogTrace trace, String line) {
         GCLogTrace concurrentBlock = CONCURRENT_PHASE_END_BLOCK.parse(line);
+        if (concurrentBlock == null) {
+            LOGGER.warning("Unable to extract data from " + trace.toString());
+            return;
+        }
         try {
             publish(new ConcurrentPreClean(startOfConcurrentPhase, concurrentBlock.getDoubleGroup(11), concurrentBlock.getDoubleGroup(7), concurrentBlock.getDoubleGroup(8)));
         } catch (Throwable t) {

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
@@ -44,8 +44,6 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static com.microsoft.gctoolkit.parser.unified.UnifiedG1GCPatterns.WEAK_PROCESSING;
 
@@ -63,10 +61,6 @@ import static com.microsoft.gctoolkit.parser.unified.UnifiedG1GCPatterns.WEAK_PR
 public class GenerationalHeapParser extends PreUnifiedGCLogParser implements SimplePatterns, ICMSPatterns, SerialPatterns, ParallelPatterns {
 
     private static final Logger LOGGER = Logger.getLogger(GenerationalHeapParser.class.getName());
-
-    // Cached for the CMS remark/weak-reference split-bug path; avoid recompiling on every parse call.
-    // [^\n]* preserves last-match semantics of greedy .* without a ReDoS hotspot.
-    private static final Pattern DURATION_GROUP_PATTERN = Pattern.compile("[^\\n]* " + PAUSE_TIME);
 
     private ParNew parNewForwardReference;
     private GarbageCollectionTypes garbageCollectionTypeForwardReference;
@@ -1924,10 +1918,10 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
      */
     public void splitRemarkReferenceWithWeakReferenceSplitBug(GCLogTrace trace, String line) {
         GCLogTrace remarkTrace = REMARK_CLAUSE.parse(line);
-        Matcher matcher = DURATION_GROUP_PATTERN.matcher(line);
+        GCLogTrace durationTrace = SPLIT_REMARK_REFERENCE_BUG_DURATION.parse(line);
         double duration = 0.0d;
-        if (matcher.find()) {
-            duration = Double.parseDouble(matcher.group(matcher.groupCount()));
+        if (durationTrace != null) {
+            duration = durationTrace.getPauseTime();
         }
         CMSRemark collection = new CMSRemark(getClock(), GCCause.CMS_FINAL_REMARK, duration);
         MemoryPoolSummary tenured = getTotalOccupancyWithTotalHeapSizeSummary(remarkTrace, 1);

--- a/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
+++ b/parser/src/main/java/com/microsoft/gctoolkit/parser/GenerationalHeapParser.java
@@ -64,6 +64,9 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
 
     private static final Logger LOGGER = Logger.getLogger(GenerationalHeapParser.class.getName());
 
+    // Cached for the CMS remark/weak-reference split-bug path; avoid recompiling on every parse call.
+    private static final Pattern DURATION_GROUP_PATTERN = Pattern.compile(".* " + PAUSE_TIME);
+
     private ParNew parNewForwardReference;
     private GarbageCollectionTypes garbageCollectionTypeForwardReference;
     private GCCause gcCauseForwardReference;
@@ -1917,8 +1920,7 @@ public class GenerationalHeapParser extends PreUnifiedGCLogParser implements Sim
      */
     public void splitRemarkReferenceWithWeakReferenceSplitBug(GCLogTrace trace, String line) {
         GCLogTrace remarkTrace = REMARK_CLAUSE.parse(line);
-        Pattern durationGroupPattern = Pattern.compile(".* " + PAUSE_TIME);
-        Matcher matcher = durationGroupPattern.matcher(line);
+        Matcher matcher = DURATION_GROUP_PATTERN.matcher(line);
         double duration = 0.0d;
         if (matcher.find()) {
             duration = Double.parseDouble(matcher.group(matcher.groupCount()));


### PR DESCRIPTION
## Summary

`splitRemarkReferenceWithWeakReferenceSplitBug` recompiled `Pattern.compile(".* " + PAUSE_TIME)` on every call. That matches other parser patterns that already use `static final` compiled patterns.

This change introduces `DURATION_GROUP_PATTERN` and reuses it for matching.

Fixes #567

## Test plan

1. `./mvnw -pl parser -am -DskipTests compile`
2. Optional: run parser tests that cover CMS remark / weak reference split bug lines