### PR TITLE
Docs: clarify G1ConcurrentStringDeduplication units

### DIFF
--- a/api/src/main/java/com/microsoft/gctoolkit/event/g1gc/G1ConcurrentStringDeduplication.java
+++ b/api/src/main/java/com/microsoft/gctoolkit/event/g1gc/G1ConcurrentStringDeduplication.java
@@ -7,14 +7,25 @@ import com.microsoft.gctoolkit.event.GarbageCollectionTypes;
 import com.microsoft.gctoolkit.time.DateTimeStamp;
 
 /**
- * 2015-10-17T21:10:23.673-0400: 3993.137: [GC concurrent-string-deduplication, 79.3K-&gt;792.0B(78.6K), avg 96.2%, 0.0024351 secs]
+ * Concurrent string deduplication statistics from a G1 GC log line such as:
+ * {@code 2015-10-17T21:10:23.673-0400: 3993.137: [GC concurrent-string-deduplication, 79.3K->792.0B(78.6K), avg 96.2%, 0.0024351 secs]}
+ *
+ * <p>String volume fields ({@link #getStartingStringVolume()}, {@link #getEndingStringVolume()}, and
+ * {@link #getReduction()}) are expressed in kilobytes (KiB), matching the parser's conversion of
+ * log sizes such as {@code B}, {@code K}, {@code M}, and {@code G} into K units.
+ *
+ * <p>{@link #getPercentReduction()} is the average reduction percentage from the log (for example,
+ * {@code avg 96.2%} is represented as {@code 96.2}, not {@code 0.962}).
  */
-
 public class G1ConcurrentStringDeduplication extends G1GCConcurrentEvent {
 
+    /** Occupied string table size before deduplication, in kilobytes. */
     private double startingStringVolume;
+    /** Occupied string table size after deduplication, in kilobytes. */
     private double endingStringVolume;
+    /** Size removed by deduplication, in kilobytes. */
     private double reduction;
+    /** Average reduction percentage where {@code 100.0} means 100%. */
     private double percentReduction;
 
     public G1ConcurrentStringDeduplication(DateTimeStamp timeStamp, double startingStringVolume, double endingStringVolume, double reduction, double percentReduction, double duration) {
@@ -29,18 +40,24 @@ public class G1ConcurrentStringDeduplication extends G1GCConcurrentEvent {
         this.percentReduction = percentReduction;
     }
 
+    /** @return occupied string table size before deduplication, in kilobytes */
     public double getStartingStringVolume() {
         return startingStringVolume;
     }
 
+    /** @return occupied string table size after deduplication, in kilobytes */
     public double getEndingStringVolume() {
         return endingStringVolume;
     }
 
+    /** @return size removed by deduplication, in kilobytes */
     public double getReduction() {
         return reduction;
     }
 
+    /**
+     * @return average reduction percentage where {@code 100.0} means 100%
+     */
     public double getPercentReduction() {
         return percentReduction;
     }


### PR DESCRIPTION
## Summary
Fixes #103

Documents that string volume and reduction values are in kilobytes (as produced by the parser's `toKBytes` conversion), and that `percentReduction` uses a 100 based percentage (`96.2` means 96.2%).

## Test plan
* [ ] Review the class and getter Javadoc
* [ ] Confirm no behavior changes